### PR TITLE
Husky setup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd frontend && npm run lint && npm run typecheck

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "husky": "^9.1.7",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.1",
         "typescript": "~5.9.3",
@@ -3066,6 +3067,22 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "typecheck": "tsc --noEmit",
+    "preview": "vite preview",
+    "prepare": "husky"
   },
   "dependencies": {
     "axios": "^1.13.6",
@@ -27,6 +29,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "husky": "^9.1.7",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3",


### PR DESCRIPTION
## Issue Link
None
Closes #
None

## Description
Adicionei o setup do Husky, ele atualmente roda somente scripts de check para o front independente de não possuir alterações no mesmo. Bem simples.
## Task Notes
Queria conversar com todos sobre a possibilidade de adicionar o `./mvnw -q compile` como pre-commit também, assim temos o check na aplicação por inteiro. Consigo também adicionar checks específicos para que rodem os scripts somente nas pastas que tiverem algum arquivo em stage para commit. Assim quando a task for específica de front ou back, irá rodar os comandos somente onde há mudanças.
## Screenshots