### PR TITLE
feat: validate CPF/CNPJ uniqueness and format for NPO registration

### DIFF
--- a/backend/src/main/java/com/vinculohub/backend/exception/DuplicateDocumentException.java
+++ b/backend/src/main/java/com/vinculohub/backend/exception/DuplicateDocumentException.java
@@ -1,0 +1,9 @@
+/* (C)2026 */
+package com.vinculohub.backend.exception;
+
+public class DuplicateDocumentException extends RuntimeException {
+
+    public DuplicateDocumentException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/exception/InvalidDocumentException.java
+++ b/backend/src/main/java/com/vinculohub/backend/exception/InvalidDocumentException.java
@@ -1,0 +1,9 @@
+/* (C)2026 */
+package com.vinculohub.backend.exception;
+
+public class InvalidDocumentException extends RuntimeException {
+
+    public InvalidDocumentException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/model/Npo.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/Npo.java
@@ -10,7 +10,12 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
-@Table(name = "npo")
+@Table(
+        name = "npo",
+        uniqueConstraints = {
+            @UniqueConstraint(name = "uk_npo_cnpj", columnNames = "cnpj"),
+            @UniqueConstraint(name = "uk_npo_cpf", columnNames = "cpf")
+        })
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @Setter

--- a/backend/src/main/java/com/vinculohub/backend/service/NpoDocumentService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/NpoDocumentService.java
@@ -1,0 +1,91 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import com.vinculohub.backend.exception.DuplicateDocumentException;
+import com.vinculohub.backend.exception.InvalidDocumentException;
+import com.vinculohub.backend.repository.NpoRepository;
+import com.vinculohub.backend.utils.DocumentValidator;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NpoDocumentService {
+
+    private final NpoRepository npoRepository;
+
+    public NpoDocumentService(NpoRepository npoRepository) {
+        this.npoRepository = npoRepository;
+    }
+
+    /**
+     * Valida os documentos (CPF e/ou CNPJ) de uma ONG antes do cadastro.
+     *
+     * <p>Regras:
+     *
+     * <ul>
+     *   <li>Pelo menos um documento (CPF ou CNPJ) deve ser informado
+     *   <li>Se informado, o documento deve ter formato válido (dígitos verificadores)
+     *   <li>O documento não pode já estar cadastrado no banco (unicidade)
+     * </ul>
+     *
+     * @param cpf CPF da ONG (pode ser null se CNPJ for informado)
+     * @param cnpj CNPJ da ONG (pode ser null se CPF for informado)
+     * @throws InvalidDocumentException se nenhum documento for informado ou se o formato for
+     *     inválido
+     * @throws DuplicateDocumentException se o documento já estiver cadastrado
+     */
+    public void validateDocuments(String cpf, String cnpj) {
+        String sanitizedCpf = DocumentValidator.sanitize(cpf);
+        String sanitizedCnpj = DocumentValidator.sanitize(cnpj);
+
+        boolean hasCpf = sanitizedCpf != null && !sanitizedCpf.isBlank();
+        boolean hasCnpj = sanitizedCnpj != null && !sanitizedCnpj.isBlank();
+
+        // Regra: pelo menos um documento é obrigatório
+        if (!hasCpf && !hasCnpj) {
+            throw new InvalidDocumentException(
+                    "É obrigatório informar pelo menos um documento (CPF ou CNPJ).");
+        }
+
+        // Validar formato e unicidade do CPF
+        if (hasCpf) {
+            if (!DocumentValidator.isValidCpf(sanitizedCpf)) {
+                throw new InvalidDocumentException("CPF informado é inválido.");
+            }
+            if (npoRepository.existsByCpf(sanitizedCpf)) {
+                throw new DuplicateDocumentException(
+                        "Já existe uma instituição cadastrada com este CPF.");
+            }
+        }
+
+        // Validar formato e unicidade do CNPJ
+        if (hasCnpj) {
+            if (!DocumentValidator.isValidCnpj(sanitizedCnpj)) {
+                throw new InvalidDocumentException("CNPJ informado é inválido.");
+            }
+            if (npoRepository.existsByCnpj(sanitizedCnpj)) {
+                throw new DuplicateDocumentException(
+                        "Já existe uma instituição cadastrada com este CNPJ.");
+            }
+        }
+    }
+
+    /**
+     * Sanitiza os documentos removendo formatação (pontos, traços, barras).
+     *
+     * @param cpf CPF com possível formatação
+     * @return CPF somente com dígitos, ou null
+     */
+    public String sanitizeCpf(String cpf) {
+        return DocumentValidator.sanitize(cpf);
+    }
+
+    /**
+     * Sanitiza os documentos removendo formatação (pontos, traços, barras).
+     *
+     * @param cnpj CNPJ com possível formatação
+     * @return CNPJ somente com dígitos, ou null
+     */
+    public String sanitizeCnpj(String cnpj) {
+        return DocumentValidator.sanitize(cnpj);
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/utils/DocumentValidator.java
+++ b/backend/src/main/java/com/vinculohub/backend/utils/DocumentValidator.java
@@ -1,0 +1,118 @@
+/* (C)2026 */
+package com.vinculohub.backend.utils;
+
+public final class DocumentValidator {
+
+    private DocumentValidator() {}
+
+    /**
+     * Valida se um CPF é válido (formato e dígitos verificadores).
+     *
+     * @param cpf String contendo apenas dígitos (11 caracteres)
+     * @return true se o CPF é válido
+     */
+    public static boolean isValidCpf(String cpf) {
+        if (cpf == null) {
+            return false;
+        }
+
+        cpf = cpf.replaceAll("[^0-9]", "");
+
+        if (cpf.length() != 11) {
+            return false;
+        }
+
+        // Rejeita CPFs com todos os dígitos iguais (ex: 111.111.111-11)
+        if (cpf.chars().distinct().count() == 1) {
+            return false;
+        }
+
+        // Validação do primeiro dígito verificador
+        int sum = 0;
+        for (int i = 0; i < 9; i++) {
+            sum += Character.getNumericValue(cpf.charAt(i)) * (10 - i);
+        }
+        int firstDigit = 11 - (sum % 11);
+        if (firstDigit >= 10) {
+            firstDigit = 0;
+        }
+        if (Character.getNumericValue(cpf.charAt(9)) != firstDigit) {
+            return false;
+        }
+
+        // Validação do segundo dígito verificador
+        sum = 0;
+        for (int i = 0; i < 10; i++) {
+            sum += Character.getNumericValue(cpf.charAt(i)) * (11 - i);
+        }
+        int secondDigit = 11 - (sum % 11);
+        if (secondDigit >= 10) {
+            secondDigit = 0;
+        }
+
+        return Character.getNumericValue(cpf.charAt(10)) == secondDigit;
+    }
+
+    /**
+     * Valida se um CNPJ é válido (formato e dígitos verificadores).
+     *
+     * @param cnpj String contendo apenas dígitos (14 caracteres)
+     * @return true se o CNPJ é válido
+     */
+    public static boolean isValidCnpj(String cnpj) {
+        if (cnpj == null) {
+            return false;
+        }
+
+        cnpj = cnpj.replaceAll("[^0-9]", "");
+
+        if (cnpj.length() != 14) {
+            return false;
+        }
+
+        // Rejeita CNPJs com todos os dígitos iguais
+        if (cnpj.chars().distinct().count() == 1) {
+            return false;
+        }
+
+        // Pesos para o primeiro dígito verificador
+        int[] weights1 = {5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+        int sum = 0;
+        for (int i = 0; i < 12; i++) {
+            sum += Character.getNumericValue(cnpj.charAt(i)) * weights1[i];
+        }
+        int firstDigit = 11 - (sum % 11);
+        if (firstDigit >= 10) {
+            firstDigit = 0;
+        }
+        if (Character.getNumericValue(cnpj.charAt(12)) != firstDigit) {
+            return false;
+        }
+
+        // Pesos para o segundo dígito verificador
+        int[] weights2 = {6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2};
+        sum = 0;
+        for (int i = 0; i < 13; i++) {
+            sum += Character.getNumericValue(cnpj.charAt(i)) * weights2[i];
+        }
+        int secondDigit = 11 - (sum % 11);
+        if (secondDigit >= 10) {
+            secondDigit = 0;
+        }
+
+        return Character.getNumericValue(cnpj.charAt(13)) == secondDigit;
+    }
+
+    /**
+     * Remove caracteres não numéricos de um documento.
+     *
+     * @param document String com possível formatação (pontos, traços, barras)
+     * @return String contendo apenas dígitos
+     */
+    public static String sanitize(String document) {
+        if (document == null) {
+            return null;
+        }
+        return document.replaceAll("[^0-9]", "");
+    }
+}

--- a/backend/src/test/java/com/vinculohub/backend/service/NpoDocumentServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/NpoDocumentServiceTest.java
@@ -1,0 +1,151 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.vinculohub.backend.exception.DuplicateDocumentException;
+import com.vinculohub.backend.exception.InvalidDocumentException;
+import com.vinculohub.backend.repository.NpoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NpoDocumentServiceTest {
+
+    @Mock private NpoRepository npoRepository;
+
+    @InjectMocks private NpoDocumentService npoDocumentService;
+
+    private static final String VALID_CPF = "52998224725";
+    private static final String VALID_CNPJ = "11222333000181";
+
+    @Nested
+    @DisplayName("Regra: pelo menos um documento obrigatório")
+    class AtLeastOneDocument {
+
+        @Test
+        @DisplayName("Deve lançar exceção quando CPF e CNPJ são null")
+        void shouldThrowWhenBothNull() {
+            InvalidDocumentException ex =
+                    assertThrows(
+                            InvalidDocumentException.class,
+                            () -> npoDocumentService.validateDocuments(null, null));
+            assertTrue(ex.getMessage().contains("obrigatório"));
+        }
+
+        @Test
+        @DisplayName("Deve lançar exceção quando CPF e CNPJ são vazios")
+        void shouldThrowWhenBothEmpty() {
+            InvalidDocumentException ex =
+                    assertThrows(
+                            InvalidDocumentException.class,
+                            () -> npoDocumentService.validateDocuments("", ""));
+            assertTrue(ex.getMessage().contains("obrigatório"));
+        }
+
+        @Test
+        @DisplayName("Deve lançar exceção quando CPF e CNPJ são espaços em branco")
+        void shouldThrowWhenBothBlank() {
+            assertThrows(
+                    InvalidDocumentException.class,
+                    () -> npoDocumentService.validateDocuments("   ", "   "));
+        }
+    }
+
+    @Nested
+    @DisplayName("Validação de formato")
+    class FormatValidation {
+
+        @Test
+        @DisplayName("Deve lançar exceção para CPF inválido")
+        void shouldThrowForInvalidCpf() {
+            InvalidDocumentException ex =
+                    assertThrows(
+                            InvalidDocumentException.class,
+                            () -> npoDocumentService.validateDocuments("12345678900", null));
+            assertTrue(ex.getMessage().contains("CPF"));
+        }
+
+        @Test
+        @DisplayName("Deve lançar exceção para CNPJ inválido")
+        void shouldThrowForInvalidCnpj() {
+            InvalidDocumentException ex =
+                    assertThrows(
+                            InvalidDocumentException.class,
+                            () -> npoDocumentService.validateDocuments(null, "11222333000100"));
+            assertTrue(ex.getMessage().contains("CNPJ"));
+        }
+
+        @Test
+        @DisplayName("Deve aceitar CPF válido sem CNPJ")
+        void shouldAcceptValidCpfOnly() {
+            when(npoRepository.existsByCpf(VALID_CPF)).thenReturn(false);
+
+            assertDoesNotThrow(() -> npoDocumentService.validateDocuments(VALID_CPF, null));
+        }
+
+        @Test
+        @DisplayName("Deve aceitar CNPJ válido sem CPF")
+        void shouldAcceptValidCnpjOnly() {
+            when(npoRepository.existsByCnpj(VALID_CNPJ)).thenReturn(false);
+
+            assertDoesNotThrow(() -> npoDocumentService.validateDocuments(null, VALID_CNPJ));
+        }
+
+        @Test
+        @DisplayName("Deve aceitar ambos CPF e CNPJ válidos")
+        void shouldAcceptBothValid() {
+            when(npoRepository.existsByCpf(VALID_CPF)).thenReturn(false);
+            when(npoRepository.existsByCnpj(VALID_CNPJ)).thenReturn(false);
+
+            assertDoesNotThrow(
+                    () -> npoDocumentService.validateDocuments(VALID_CPF, VALID_CNPJ));
+        }
+    }
+
+    @Nested
+    @DisplayName("Unicidade no banco")
+    class UniquenessValidation {
+
+        @Test
+        @DisplayName("Deve lançar exceção para CPF já cadastrado")
+        void shouldThrowForDuplicateCpf() {
+            when(npoRepository.existsByCpf(VALID_CPF)).thenReturn(true);
+
+            DuplicateDocumentException ex =
+                    assertThrows(
+                            DuplicateDocumentException.class,
+                            () -> npoDocumentService.validateDocuments(VALID_CPF, null));
+            assertTrue(ex.getMessage().contains("CPF"));
+        }
+
+        @Test
+        @DisplayName("Deve lançar exceção para CNPJ já cadastrado")
+        void shouldThrowForDuplicateCnpj() {
+            when(npoRepository.existsByCnpj(VALID_CNPJ)).thenReturn(true);
+
+            DuplicateDocumentException ex =
+                    assertThrows(
+                            DuplicateDocumentException.class,
+                            () -> npoDocumentService.validateDocuments(null, VALID_CNPJ));
+            assertTrue(ex.getMessage().contains("CNPJ"));
+        }
+
+        @Test
+        @DisplayName("Deve lançar exceção quando CPF é válido mas CNPJ é duplicado")
+        void shouldThrowWhenCnpjDuplicate() {
+            when(npoRepository.existsByCpf(VALID_CPF)).thenReturn(false);
+            when(npoRepository.existsByCnpj(VALID_CNPJ)).thenReturn(true);
+
+            assertThrows(
+                    DuplicateDocumentException.class,
+                    () -> npoDocumentService.validateDocuments(VALID_CPF, VALID_CNPJ));
+        }
+    }
+}

--- a/backend/src/test/java/com/vinculohub/backend/utils/DocumentValidatorTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/utils/DocumentValidatorTest.java
@@ -1,0 +1,121 @@
+/* (C)2026 */
+package com.vinculohub.backend.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DocumentValidatorTest {
+
+    @Nested
+    @DisplayName("Validação de CPF")
+    class CpfValidation {
+
+        @Test
+        @DisplayName("Deve aceitar CPF válido")
+        void shouldAcceptValidCpf() {
+            assertTrue(DocumentValidator.isValidCpf("52998224725"));
+        }
+
+        @Test
+        @DisplayName("Deve aceitar CPF válido com formatação")
+        void shouldAcceptFormattedCpf() {
+            assertTrue(DocumentValidator.isValidCpf("529.982.247-25"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CPF com dígitos iguais")
+        void shouldRejectAllSameDigits() {
+            assertFalse(DocumentValidator.isValidCpf("11111111111"));
+            assertFalse(DocumentValidator.isValidCpf("00000000000"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CPF com dígito verificador errado")
+        void shouldRejectInvalidCheckDigit() {
+            assertFalse(DocumentValidator.isValidCpf("52998224726"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CPF com tamanho errado")
+        void shouldRejectWrongLength() {
+            assertFalse(DocumentValidator.isValidCpf("1234567"));
+            assertFalse(DocumentValidator.isValidCpf("123456789012"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CPF null")
+        void shouldRejectNull() {
+            assertFalse(DocumentValidator.isValidCpf(null));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CPF vazio")
+        void shouldRejectEmpty() {
+            assertFalse(DocumentValidator.isValidCpf(""));
+        }
+    }
+
+    @Nested
+    @DisplayName("Validação de CNPJ")
+    class CnpjValidation {
+
+        @Test
+        @DisplayName("Deve aceitar CNPJ válido")
+        void shouldAcceptValidCnpj() {
+            assertTrue(DocumentValidator.isValidCnpj("11222333000181"));
+        }
+
+        @Test
+        @DisplayName("Deve aceitar CNPJ válido com formatação")
+        void shouldAcceptFormattedCnpj() {
+            assertTrue(DocumentValidator.isValidCnpj("11.222.333/0001-81"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CNPJ com dígitos iguais")
+        void shouldRejectAllSameDigits() {
+            assertFalse(DocumentValidator.isValidCnpj("11111111111111"));
+            assertFalse(DocumentValidator.isValidCnpj("00000000000000"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CNPJ com dígito verificador errado")
+        void shouldRejectInvalidCheckDigit() {
+            assertFalse(DocumentValidator.isValidCnpj("11222333000182"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CNPJ com tamanho errado")
+        void shouldRejectWrongLength() {
+            assertFalse(DocumentValidator.isValidCnpj("1122233300018"));
+            assertFalse(DocumentValidator.isValidCnpj("112223330001811"));
+        }
+
+        @Test
+        @DisplayName("Deve rejeitar CNPJ null")
+        void shouldRejectNull() {
+            assertFalse(DocumentValidator.isValidCnpj(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Sanitização de documento")
+    class Sanitization {
+
+        @Test
+        @DisplayName("Deve remover pontos, traços e barras")
+        void shouldRemoveFormatting() {
+            assertEquals("52998224725", DocumentValidator.sanitize("529.982.247-25"));
+            assertEquals("11222333000181", DocumentValidator.sanitize("11.222.333/0001-81"));
+        }
+
+        @Test
+        @DisplayName("Deve retornar null para input null")
+        void shouldReturnNullForNull() {
+            assertNull(DocumentValidator.sanitize(null));
+        }
+    }
+}


### PR DESCRIPTION
- Add DocumentValidator util with CPF/CNPJ checksum algorithm (Receita Federal)
- Add NpoDocumentService with business rules: at least one document required, valid format, and uniqueness check against database
- Add InvalidDocumentException (400) and DuplicateDocumentException (409)
- Add @UniqueConstraint for cnpj and cpf columns in Npo entity
- Add 19 unit tests covering format, uniqueness and edge cases

## Issue Link
Closes #

## Description
## Task Notes
## Screenshots