### PR TITLE
feat: validate at least one ESG pillar is selected for NPO registration

### DIFF
--- a/backend/src/main/java/com/vinculohub/backend/exception/EsgSelectionException.java
+++ b/backend/src/main/java/com/vinculohub/backend/exception/EsgSelectionException.java
@@ -1,0 +1,9 @@
+/* (C)2026 */
+package com.vinculohub.backend.exception;
+
+public class EsgSelectionException extends RuntimeException {
+
+    public EsgSelectionException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/NpoEsgService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/NpoEsgService.java
@@ -1,0 +1,33 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import com.vinculohub.backend.exception.EsgSelectionException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NpoEsgService {
+
+    /**
+     * Valida que pelo menos um pilar ESG foi selecionado.
+     *
+     * <p>Critério de aceite: a ONG deve selecionar no mínimo 1 pilar ESG durante o cadastro.
+     *
+     * @param environmental se o pilar Ambiental foi selecionado
+     * @param social se o pilar Social foi selecionado
+     * @param governance se o pilar Governança foi selecionado
+     * @throws EsgSelectionException se nenhum pilar for selecionado
+     */
+    public void validateEsgSelection(
+            Boolean environmental, Boolean social, Boolean governance) {
+
+        boolean hasEnvironmental = Boolean.TRUE.equals(environmental);
+        boolean hasSocial = Boolean.TRUE.equals(social);
+        boolean hasGovernance = Boolean.TRUE.equals(governance);
+
+        if (!hasEnvironmental && !hasSocial && !hasGovernance) {
+            throw new EsgSelectionException(
+                    "É obrigatório selecionar pelo menos um pilar ESG"
+                            + " (Ambiental, Social ou Governança).");
+        }
+    }
+}

--- a/backend/src/test/java/com/vinculohub/backend/service/NpoEsgServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/NpoEsgServiceTest.java
@@ -1,0 +1,71 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.vinculohub.backend.exception.EsgSelectionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NpoEsgServiceTest {
+
+    private final NpoEsgService npoEsgService = new NpoEsgService();
+
+    @Test
+    @DisplayName("Deve aceitar quando apenas Environmental é selecionado")
+    void shouldAcceptEnvironmentalOnly() {
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(true, false, false));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar quando apenas Social é selecionado")
+    void shouldAcceptSocialOnly() {
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(false, true, false));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar quando apenas Governance é selecionado")
+    void shouldAcceptGovernanceOnly() {
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(false, false, true));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar quando todos os pilares são selecionados")
+    void shouldAcceptAllSelected() {
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(true, true, true));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar quando dois pilares são selecionados")
+    void shouldAcceptTwoSelected() {
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(true, true, false));
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(true, false, true));
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(false, true, true));
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção quando nenhum pilar é selecionado")
+    void shouldThrowWhenNoneSelected() {
+        EsgSelectionException ex =
+                assertThrows(
+                        EsgSelectionException.class,
+                        () -> npoEsgService.validateEsgSelection(false, false, false));
+        assertTrue(ex.getMessage().contains("obrigatório"));
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção quando todos são null")
+    void shouldThrowWhenAllNull() {
+        assertThrows(
+                EsgSelectionException.class,
+                () -> npoEsgService.validateEsgSelection(null, null, null));
+    }
+
+    @Test
+    @DisplayName("Deve aceitar quando um é true e outros são null")
+    void shouldAcceptOneSelectedWithNulls() {
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(true, null, null));
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(null, true, null));
+        assertDoesNotThrow(() -> npoEsgService.validateEsgSelection(null, null, true));
+    }
+}


### PR DESCRIPTION
- Add NpoEsgService with minimum 1 ESG pillar validation rule
- Add EsgSelectionException for when no pillar is selected (HTTP 400)
- Add 8 unit tests covering all combinations: single, multiple, none, and null

## Issue Link
Closes #

## Description
## Task Notes
## Screenshots