### PR TITLE
setup app router to define app routes

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './styles/main.css' 
-import ComponentsPage from './pages/ComponentsPage/index' 
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import "./styles/main.css"
+import { AppRouter } from "./router"
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ComponentsPage />
+    <AppRouter />
   </StrictMode>,
 )

--- a/frontend/src/pages/LandingPage/index.tsx
+++ b/frontend/src/pages/LandingPage/index.tsx
@@ -1,0 +1,12 @@
+import { Header } from "../../components/general/Header"
+
+const LandingPage = () => {
+  return (
+    <div className="min-h-screen bg-slate-50 flex flex-col gap-10 pb-20">
+      <Header />
+      <h1>Landing Page</h1>
+    </div>
+  )
+}
+
+export default LandingPage

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -1,10 +1,12 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import ComponentsPage from '../pages/ComponentsPage/index';
+import { BrowserRouter, Routes, Route } from "react-router-dom"
+import LandingPage from "../pages/LandingPage"
+import ComponentsPage from "../pages/ComponentsPage"
 
 export const AppRouter = () => (
   <BrowserRouter>
     <Routes>
-      <Route path="/" element={<ComponentsPage />} />
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/components" element={<ComponentsPage />} />
     </Routes>
   </BrowserRouter>
-);
+)


### PR DESCRIPTION
## Issue Link
Closes #

## Description
Arrumei o main para usar o App Router, agora qualquer page nova pode setar sua rota no router.
Adicionei também uma LandingPage dummy padrão só para termos uma rota na raiz no momento.
## Task Notes
Configurei `/components` para acessar a tela de componentes genéricos feita pelo @MarciusMoraes para que qualquer um que queira verificar a implementação dos componentes existentes.
## Screenshots