### PR TITLE
fix: wizard persistence, cross-entity validation, pre-auth0 checks and role enforcement

### DIFF
--- a/ai-docs/revisao-codigo.md
+++ b/ai-docs/revisao-codigo.md
@@ -1,7 +1,7 @@
 # VinculoHub Portal — Revisão de Código
 
 > **Escopo:** Análise completa de consistência, qualidade e prontidão para produção.
-> **Última atualização:** Abril 2026
+> **Última atualização:** Abril 2026 (sprint 1)
 
 ---
 
@@ -58,71 +58,17 @@
 | Falha no CEP travava campos permanentemente | Campos de endereço agora editáveis quando CEP não retornou dados (`disabled={!!zipCodeData}`). Ambos os fluxos. |
 | Queries CNPJ/CEP em todos os steps | Queries agora limitadas ao step relevante (CNPJ no step 2, CEP no step 3). |
 | `useAuthenticatedApi` nunca importado | Removido de `api.ts`. Imports desnecessários de `useAuth0` e `useMemo` limpos. |
+| **#1.1** Estado do wizard perdido ao recarregar | Hook `useWizardPersistence<T>` criado. Persiste `currentStep` + dados do formulário no `sessionStorage` a cada mudança e reidrata na montagem. Chaves: `vinculohub:npo-wizard-progress` e `vinculohub:company-wizard-progress`. `AuthRoleRedirect` limpa as chaves após submissão bem-sucedida. |
+| **#1.2** Erros de cadastro engolidos — dashboard sem conta | `AuthRoleRedirect`: catch de falha no POST agora remove draft + progress do `sessionStorage`, exibe toast via `ToastContext` (MUI Snackbar) e redireciona para `/cadastro` com `return`. Usuário não chega ao dashboard sem conta no banco. |
+| **#1.3** Sem validação cruzada de CPF/CNPJ entre ONG e Empresa | Backend: `DocumentCheckService` + `DocumentCheckController` (`GET /public/validate/cnpj`, `/cpf`, `/email`) consultam ambas as tabelas. `NpoDocumentService` e `CompanyService` atualizados para checar cross-table. Frontend: pré-validação antes do `loginWithRedirect` com toast e abort se documento/email já em uso. Dívida técnica de feedback inline por campo permanece como melhoria futura. |
+| **#1.4** CNPJ não normalizado antes da verificação de duplicidade | `CompanyService` agora usa `DocumentValidator.sanitize()` antes do `existsByCnpj` e persiste o CNPJ sanitizado (só dígitos) na entidade. |
+| **#3.6** Sem validação de email já em uso no cadastro de empresa | Verificação de email via `checkEmailAvailable()` adicionada antes do `loginWithRedirect` na empresa. Toast exibido e fluxo abortado se email já cadastrado. |
+| **#2.1** Sem enforcement de roles nos endpoints do servidor | `@PreAuthorize("!hasRole('company') && !hasRole('admin')")` em `POST /api/npo-accounts`; `@PreAuthorize("!hasRole('npo') && !hasRole('admin')")` em `POST /api/company-accounts`; `@PreAuthorize("hasRole('admin')")` em `GET /api/me` (AuthTestController). |
+| **#2.2** Proteção de rotas no frontend apenas auth, sem verificação de papel | `ProtectedRoute` ganhou prop `requiredRole?: "ADMIN" \| "NPO" \| "COMPANY"`. Lê roles do claim `https://vinculohub/roles` no objeto `user` do Auth0. Router atualizado: `/admin/dashboard` → `ADMIN`, `/ong/dashboard` → `NPO`, `/empresa/dashboard` → `COMPANY`. |
 
 ---
 
 ## 1. Bugs e Funcionalidade
-
-### 1.1 Estado do wizard perdido ao recarregar a página
-
-| Sev/Pri | CRÍTICO / P0 |
-|---|---|
-| **Arquivos** | `frontend/src/pages/company/registration/index.tsx`, `frontend/src/pages/RegisterPage/index.tsx` |
-
-Todos os campos do formulário e o `currentStep` são `useState` efêmero. O rascunho só é salvo no `sessionStorage` antes do redirect Auth0. Qualquer recarga, restauração de aba ou navegação acidental apaga todo o progresso. Afeta ambos os fluxos (ONG e Empresa).
-
-**Correção:** Persistir step + dados do formulário no `sessionStorage` a cada mudança e reidratar na montagem.
-
----
-
-### 1.2 Erros de cadastro são engolidos — usuário vai pro dashboard sem conta
-
-| Sev/Pri | MÉDIO / P1 |
-|---|---|
-| **Arquivos** | `frontend/src/components/auth/AuthRoleRedirect.tsx` |
-
-Quando o POST do rascunho falha (409 duplicado, 400 inválido, rede), o erro é logado e o fluxo continua. O JWT já tem o role atribuído pelo Auth0, então `resolvePrimaryRole` roteia pro dashboard sem conta no banco. O rascunho permanece no `sessionStorage` e será reenviado a cada login.
-
-**Correção:** Em falha de envio, não navegar pro dashboard. Redirecionar para `/cadastro` com a mensagem de erro da API.
-
----
-
-### 1.3 Sem validação cruzada de unicidade de CPF/CNPJ entre ONG e Empresa
-
-| Sev/Pri | ALTO / P1 |
-|---|---|
-| **Arquivos** | `backend/.../service/CompanyService.java`, `backend/.../service/NpoDocumentService.java` |
-
-O sistema não garante unicidade de CPF/CNPJ entre as entidades `npo` e `company`:
-- `CompanyService.existsByCnpj` só consulta a tabela `company`
-- `NpoDocumentService` só consulta a tabela `npo`
-- Um CNPJ já utilizado por uma ONG pode ser cadastrado como empresa e vice-versa
-
-Além disso, o **frontend não tem feedback** quando o backend rejeita por duplicidade. O erro 409 é logado e engolido pelo `AuthRoleRedirect`, e o usuário é redirecionado ao dashboard sem conta. Não há mecanismo para levar o usuário de volta ao step relevante do wizard para corrigir os dados.
-
-**Correção (backend):** Criar um serviço de validação de documentos compartilhado que consulte ambas as tabelas (`npo` e `company`) antes de permitir o cadastro.
-
-**Correção (frontend — dívida técnica):** Quando o POST do rascunho falhar com 409 ou 400, o fluxo deveria:
-1. Detectar o tipo de erro (documento duplicado, email em uso, etc.)
-2. Redirecionar o usuário de volta ao step relevante do wizard (não ao dashboard)
-3. Exibir a mensagem específica da API inline no campo problemático
-4. Manter os dados preenchidos para que o usuário corrija apenas o campo com conflito
-
-Isso requer persistência do estado do wizard (ver #1.1) e um mecanismo de "retorno com erro" após o redirect do Auth0, que hoje não existe.
-
----
-
-### 1.4 CNPJ não normalizado antes da verificação de duplicidade
-
-| Sev/Pri | ALTO / P1 |
-|---|---|
-| **Arquivos** | `backend/.../service/CompanyService.java` |
-
-`existsByCnpj` compara a string bruta. O frontend envia CNPJs formatados (`12.345.678/0001-90`). Sem normalização para apenas dígitos, formatos diferentes podem burlar a checagem.
-
-**Correção:** Remover caracteres não numéricos antes da verificação e persistência (como `NpoDocumentService` já faz).
-
----
 
 ### 1.5 ONGs com nomes duplicados são aceitas sem validação
 
@@ -210,7 +156,7 @@ Email e CNPJ são logados em nível INFO. Mascarar dados sensíveis para LGPD.
 
 ## 3. Consistência de Padrões — Frontend
 
-> Itens 3.1, 3.2, 3.3, 3.5, 3.7, 3.8, 3.9, 3.10 foram **corrigidos** — ver "Problemas Já Corrigidos".
+> Itens 3.1, 3.2, 3.3, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 foram **corrigidos** — ver "Problemas Já Corrigidos".
 
 ### 3.4 Falta de padronização entre os wizards de ONG e Empresa
 
@@ -224,16 +170,6 @@ Email e CNPJ são logados em nível INFO. Mascarar dados sensíveis para LGPD.
 - ONG não tem step de resumo; Empresa tem `RegistrationSummary`
 
 **Padrão:** Extrair wizard genérico reutilizável.
-
----
-
-### 3.6 Sem validação de email já em uso no cadastro de empresa
-
-| Sev/Pri | MÉDIO / P1 |
-|---|---|
-| **Arquivos** | `frontend/src/pages/CompanyRegistration/registration/index.tsx` |
-
-O erro de email duplicado só aparece na tela do Auth0. O usuário completa o wizard inteiro, é redirecionado, e só então descobre que o email já está em uso.
 
 ---
 
@@ -293,17 +229,6 @@ CNPJ duplicado, Auth0 ID duplicado e email duplicado lançam a mesma exceção c
 
 ---
 
-### 4.5 `@Slf4j` ausente em serviços críticos
-
-| Sev/Pri | MÉDIO / P2 |
-|---|---|
-
-Sem logging: `NpoAccountService`, `NpoDocumentService`, `NpoEsgService`, `NpoService`, `AddressService`, `CepValidationService`, `CnpjValidationService`, `AuthTestController`.
-
-Serviços de integração externa (CEP, CNPJ) não logam sucesso nem falha de chamadas HTTP.
-
----
-
 ### 4.6 `@Transactional` inconsistente
 
 | Sev/Pri | BAIXO / P3 |
@@ -325,18 +250,6 @@ Cada um cria `RestClient.create()` como field. Sem timeouts, métricas ou testab
 
 ---
 
-### 4.8 Entity soft delete inconsistente
-
-| Sev/Pri | MÉDIO / P2 |
-|---|---|
-
-- `User`, `Npo`, `Address`: têm `@SQLRestriction("deleted_at IS NULL")`
-- `Company`: tem coluna `deletedAt` mas **sem** `@SQLRestriction`
-
-Queries de `Company` retornam registros soft-deleted.
-
----
-
 ### 4.9 Tabelas com nomes singular vs plural
 
 | Sev/Pri | BAIXO / P3 |
@@ -348,16 +261,6 @@ Queries de `Company` retornam registros soft-deleted.
 
 ---
 
-### 4.10 `@Temporal` desnecessário no `Company.java`
-
-| Sev/Pri | BAIXO / P3 |
-|---|---|
-| **Arquivo** | `backend/.../model/Company.java` |
-
-`@Temporal(TemporalType.TIMESTAMP)` em `LocalDateTime` é redundante em JPA 2.2+. `User` e `Npo` não usam.
-
----
-
 ### 4.11 Enums em lowercase (`admin`, `npo`) em vez de UPPERCASE
 
 | Sev/Pri | BAIXO / P3 |
@@ -365,16 +268,6 @@ Queries de `Company` retornam registros soft-deleted.
 | **Arquivos** | `enums/UserType.java`, `enums/NpoSize.java` |
 
 Convenção Java é `ADMIN`, `NPO`, `COMPANY`. Funciona com `@Enumerated(EnumType.STRING)` em lowercase, mas exige mapeamento se mudar.
-
----
-
-### 4.12 Dependência duplicada no `pom.xml`
-
-| Sev/Pri | BAIXO / P3 |
-|---|---|
-| **Arquivo** | `pom.xml` |
-
-`springdoc-openapi-starter-webmvc-ui` declarada duas vezes. `thymeleaf-extras-springsecurity6` presente sem camada Thymeleaf visível.
 
 ---
 
@@ -390,46 +283,7 @@ Nenhuma anotação `@NotBlank`, `@Email`, `@Size`. Controller não usa `@Valid`.
 
 ## 5. Mensagens e Internacionalização
 
-### 5.1 Idioma misturado nas mensagens de erro da API
-
-| Sev/Pri | MÉDIO / P2 |
-|---|---|
-
-| Arquivo | Mensagem | Idioma |
-|---|---|---|
-| `CompanyAlreadyExistsException` | "comany already exists" | EN (com typo) |
-| `CompanyService` | "Auth0 ID é obrigatório" | PT |
-| `NpoAccountService` | "sao obrigatorios", "e obrigatorio" | PT sem acento |
-| `CepNotFoundException` | "Cep not found" | EN |
-| `CnpjNotFoundException` | "CNPJ not found" | EN |
-| `GlobalExceptionHandler` | "Erro interno do servidor" | PT |
-
-**Padrão:** Escolher um idioma para mensagens de API. Se PT-BR, normalizar acentos em toda a base.
-
----
-
-### 5.2 Strings do frontend sem acento ou gramaticalmente incorretas
-
-| Sev/Pri | BAIXO / P2 |
-|---|---|
-
-| Arquivo | Exemplo | Correto |
-|---|---|---|
-| `validation.ts` (múltiplas linhas) | "instituicao", "valido", "minimo", "nao", "razao social" | "instituição", "válido", "mínimo", "não", "razão social" |
-| `company/registration/index.tsx` L274 | "Informe um e-mail valido" | "Informe um e-mail válido" |
-| `NpoStepThree.tsx` L130 | "Selecione os pilares que a ONG atua." | "Selecione os pilares em que a ONG atua." |
-
----
-
-### 5.3 Botões Login/Logout em inglês
-
-| Sev/Pri | BAIXO / P3 |
-|---|---|
-| **Arquivos** | `LoginButton.tsx`, `LogoutButton.tsx` |
-
-Texto "Log in" / "Log out" enquanto o resto da UI é em português. Esses componentes não são importados em nenhum lugar atualmente (possivelmente dead code).
-
----
+> Itens 5.1, 5.2 e 5.3 foram **corrigidos** — ver "Problemas Já Corrigidos".
 
 ## 6. Acessibilidade
 
@@ -517,42 +371,17 @@ Campo hardcoded sem lógica de negócio.
 
 ## 8. Código Morto
 
-### 8.1 Componentes e arquivos nunca importados
+### 8.1 Módulo `pages/Registering/` sem rota
 
 | Sev/Pri | BAIXO / P3 |
 |---|---|
 
 | Arquivo | Situação |
 |---|---|
-| `components/ong/OngCard.tsx` | Nunca importado |
-| `components/auth/LoginButton.tsx` | Nunca importado |
-| `components/auth/LogoutButton.tsx` | Nunca importado |
-| `utils/validateCpf.ts` | `validation.ts` duplica a lógica internamente; este nunca é importado |
-| `pages/Registering/` (3 arquivos) | Nenhuma rota em `router/index.tsx` aponta para este módulo |
+| `pages/Registering/` (pasta completa) | Nenhuma rota em `router/index.tsx` aponta para este módulo |
 | `pages/Registering/Steps/Step4.tsx` | `Enterprise_Registering_Step_4` é um export vazio |
 
----
-
-### 8.2 Código comentado em produção
-
-| Sev/Pri | BAIXO / P3 |
-|---|---|
-
-| Arquivo | O que está comentado |
-|---|---|
-| `company/registration/index.tsx` | `LogoUpload` import, estado, JSX; `entityIcon` prop |
-| `RegistrationSummary.tsx` | Bloco de ícone |
-| `RegisterPage/index.tsx` | Enterprise steps 2–5 são `<div>` placeholder |
-
----
-
-### 8.3 Validadores desalinhados com steps reais da ONG
-
-| Sev/Pri | BAIXO / P3 |
-|---|---|
-| **Arquivo** | `frontend/src/config/wizard.config.ts` |
-
-Array de validadores NPO tem 4 entradas (incluindo `() => ({})` placeholder) mas o wizard renderiza apenas 3 steps. Quarto validador nunca é executado.
+> `OngCard.tsx`, `LoginButton.tsx`, `LogoutButton.tsx`, `validateCpf.ts` e código comentado (`LogoUpload`, `entityIcon`) já foram removidos — ver "Problemas Já Corrigidos".
 
 ---
 
@@ -605,24 +434,28 @@ Array de validadores NPO tem 4 entradas (incluindo `() => ({})` placeholder) mas
 
 ## Resumo por Status
 
+> Atualizado após sprint 1 — #1.1, #1.2, #1.3, #1.4 e #3.6 corrigidos. Seções 4.5, 4.8, 4.10, 4.12, 5.1, 5.2, 5.3, 8.2, 8.3 removidas (já corrigidos).
+
 | Categoria | Crítico | Alto | Médio | Baixo |
 |---|---|---|---|---|
-| Bugs / Funcionalidade | 1 | 2 | 2 | 1 |
+| Bugs / Funcionalidade | — | — | 1 | 1 |
 | Segurança | — | 2 | 3 | 1 |
-| Padrões Frontend | — | — | 7 | 3 |
-| Padrões Backend | — | 1 | 5 | 6 |
-| Mensagens / i18n | — | — | 2 | 1 |
+| Padrões Frontend | — | — | 1 | — |
+| Padrões Backend | — | 1 | 3 | 3 |
+| Mensagens / i18n | — | — | — | — |
 | Acessibilidade | — | — | — | 4 |
 | Infra / Config | — | 2 | — | 2 |
-| Código Morto | — | — | — | 4 |
+| Código Morto | — | — | — | 1 |
 | Styling | — | — | — | 3 |
-| **Total** | **1** | **7** | **19** | **25** |
+| **Total** | **—** | **5** | **8** | **15** |
 
 ---
 
 ## Ordem de Correção Recomendada
 
-1. **P0:** Persistir estado do wizard (#1.1)
-2. **P1:** Feedback de erros e validação cruzada CPF/CNPJ (#1.2, #1.3, #3.5, #3.6); roles no servidor (#2.1) e frontend (#2.2); normalizar CNPJ (#1.4)
-3. **P2:** Quick wins de backend e frontend (ver tabelas acima); padronizar wizards (#3.4); formato de erro da API (#4.3); soft delete Company (#4.8); validação NPO DTO (#4.13); mensagens PT-BR (#5.1, #5.2)
-4. **P3:** Limpeza de código morto (#8.*); acessibilidade (#6.*); infraestrutura (#7.*); polimento de styling (#9.*)
+1. ~~**P0:** Persistir estado do wizard (#1.1)~~ ✅
+2. ~~**P1:** Feedback de erros e validação cruzada CPF/CNPJ (#1.2, #1.3); normalizar CNPJ (#1.4)~~ ✅
+3. ~~**P1:** Validação de email no cadastro de empresa (#3.6)~~ ✅
+4. ~~**P1:** Roles no servidor (#2.1) e frontend (#2.2)~~ ✅
+5. **P2:** Quick wins de backend e frontend (ver tabelas acima); padronizar wizards (#3.4); formato de erro da API (#4.3); validação NPO DTO (#4.13)
+6. **P3:** Limpeza de código morto (#8.*); acessibilidade (#6.*); infraestrutura (#7.*); polimento de styling (#9.*)

--- a/backend/src/main/java/com/vinculohub/backend/controller/AuthTestController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/AuthTestController.java
@@ -29,7 +29,7 @@ public class AuthTestController {
     }
 
     @GetMapping("/api/me")
-    @PreAuthorize("hasRole('admin')")
+    @PreAuthorize("hasRole('ADMIN')")
     public Map<String, Object> me(@AuthenticationPrincipal Jwt jwt) {
         List<String> authorities =
                 jwt.getClaimAsStringList("scope") == null

--- a/backend/src/main/java/com/vinculohub/backend/controller/AuthTestController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/AuthTestController.java
@@ -4,6 +4,7 @@ package com.vinculohub.backend.controller;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +29,7 @@ public class AuthTestController {
     }
 
     @GetMapping("/api/me")
+    @PreAuthorize("hasRole('admin')")
     public Map<String, Object> me(@AuthenticationPrincipal Jwt jwt) {
         List<String> authorities =
                 jwt.getClaimAsStringList("scope") == null

--- a/backend/src/main/java/com/vinculohub/backend/controller/CompanyController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/CompanyController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import jakarta.validation.Valid;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,7 @@ public class CompanyController {
     private final CompanyService companyService;
 
     @PostMapping("/api/company-accounts")
+    @PreAuthorize("!hasRole('npo') && !hasRole('admin')")
     public ResponseEntity<CompanyDTO> createCompany(
             @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody CompanyDTO companyDTO) {
         log.info("POST /api/company-accounts | sub={} email={} cnpj={}",

--- a/backend/src/main/java/com/vinculohub/backend/controller/CompanyController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/CompanyController.java
@@ -20,7 +20,7 @@ public class CompanyController {
     private final CompanyService companyService;
 
     @PostMapping("/api/company-accounts")
-    @PreAuthorize("!hasRole('npo') && !hasRole('admin')")
+    @PreAuthorize("!hasRole('NPO') && !hasRole('ADMIN')")
     public ResponseEntity<CompanyDTO> createCompany(
             @AuthenticationPrincipal Jwt jwt, @Valid @RequestBody CompanyDTO companyDTO) {
         log.info("POST /api/company-accounts | sub={} email={} cnpj={}",

--- a/backend/src/main/java/com/vinculohub/backend/controller/DocumentCheckController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/DocumentCheckController.java
@@ -1,0 +1,40 @@
+/* (C)2026 */
+package com.vinculohub.backend.controller;
+
+import com.vinculohub.backend.service.DocumentCheckService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/public/validate")
+@RequiredArgsConstructor
+public class DocumentCheckController {
+
+    private final DocumentCheckService documentCheckService;
+
+    @GetMapping("/cnpj/{cnpj}")
+    public ResponseEntity<Map<String, Boolean>> checkCnpj(@PathVariable String cnpj) {
+        boolean available = documentCheckService.isCnpjAvailable(cnpj);
+        return ResponseEntity.ok(Map.of("available", available));
+    }
+
+    @GetMapping("/cpf/{cpf}")
+    public ResponseEntity<Map<String, Boolean>> checkCpf(@PathVariable String cpf) {
+        boolean available = documentCheckService.isCpfAvailable(cpf);
+        return ResponseEntity.ok(Map.of("available", available));
+    }
+
+    @GetMapping("/email")
+    public ResponseEntity<Map<String, Boolean>> checkEmail(@RequestParam String value) {
+        boolean available = documentCheckService.isEmailAvailable(value);
+        return ResponseEntity.ok(Map.of("available", available));
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/controller/NpoAccountController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/NpoAccountController.java
@@ -11,6 +11,7 @@ import com.vinculohub.backend.service.NpoAccountService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
@@ -27,6 +28,7 @@ public class NpoAccountController {
     }
 
     @PostMapping
+    @PreAuthorize("!hasRole('company') && !hasRole('admin')")
     public ResponseEntity<NpoInstitutionalSignupResponse> create(
             @AuthenticationPrincipal Jwt jwt, @RequestBody NpoInstitutionalSignupRequest request) {
         log.info("POST /api/npo-accounts | sub={} email={}", jwt.getSubject(), jwt.getClaimAsString("email"));

--- a/backend/src/main/java/com/vinculohub/backend/controller/NpoAccountController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/NpoAccountController.java
@@ -28,7 +28,7 @@ public class NpoAccountController {
     }
 
     @PostMapping
-    @PreAuthorize("!hasRole('company') && !hasRole('admin')")
+    @PreAuthorize("!hasRole('COMPANY') && !hasRole('ADMIN')")
     public ResponseEntity<NpoInstitutionalSignupResponse> create(
             @AuthenticationPrincipal Jwt jwt, @RequestBody NpoInstitutionalSignupRequest request) {
         log.info("POST /api/npo-accounts | sub={} email={}", jwt.getSubject(), jwt.getClaimAsString("email"));

--- a/backend/src/main/java/com/vinculohub/backend/service/CompanyService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/CompanyService.java
@@ -10,7 +10,9 @@ import com.vinculohub.backend.model.Company;
 import com.vinculohub.backend.model.User;
 import com.vinculohub.backend.model.enums.UserType;
 import com.vinculohub.backend.repository.CompanyRepository;
+import com.vinculohub.backend.repository.NpoRepository;
 import com.vinculohub.backend.repository.UserRepository;
+import com.vinculohub.backend.utils.DocumentValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CompanyService {
 
     private final CompanyRepository companyRepository;
+    private final NpoRepository npoRepository;
     private final AddressService addressService;
     private final UserRepository userRepository;
 
@@ -34,9 +37,10 @@ public class CompanyService {
             throw new BadRequestException("Auth0 ID é obrigatório.");
         }
 
-        if (companyRepository.existsByCnpj(companyDTO.cnpj())) {
-            log.warn("Duplicate CNPJ: {}", companyDTO.cnpj());
-            throw new CompanyAlreadyExistsException("Já existe uma empresa cadastrada com este CNPJ.");
+        String sanitizedCnpj = DocumentValidator.sanitize(companyDTO.cnpj());
+        if (companyRepository.existsByCnpj(sanitizedCnpj) || npoRepository.existsByCnpj(sanitizedCnpj)) {
+            log.warn("Duplicate CNPJ: {}", sanitizedCnpj);
+            throw new CompanyAlreadyExistsException("Já existe uma instituição cadastrada com este CNPJ.");
         }
 
         if (userRepository.existsByAuth0Id(auth0Id)) {
@@ -63,7 +67,7 @@ public class CompanyService {
         company.setSocialName(companyDTO.socialName());
         company.setDescription(companyDTO.description());
         company.setLogoUrl(firstPresent(companyDTO.logoUrl(), ""));
-        company.setCnpj(companyDTO.cnpj());
+        company.setCnpj(sanitizedCnpj);
         company.setPhone(companyDTO.phone());
 
         log.info("Creating address...");

--- a/backend/src/main/java/com/vinculohub/backend/service/DocumentCheckService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/DocumentCheckService.java
@@ -1,0 +1,49 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import com.vinculohub.backend.repository.CompanyRepository;
+import com.vinculohub.backend.repository.NpoRepository;
+import com.vinculohub.backend.repository.UserRepository;
+import com.vinculohub.backend.utils.DocumentValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DocumentCheckService {
+
+    private final NpoRepository npoRepository;
+    private final CompanyRepository companyRepository;
+    private final UserRepository userRepository;
+
+    public boolean isCnpjAvailable(String cnpj) {
+        String sanitized = DocumentValidator.sanitize(cnpj);
+        if (sanitized == null || sanitized.isBlank()) {
+            return true;
+        }
+        boolean inUse = npoRepository.existsByCnpj(sanitized) || companyRepository.existsByCnpj(sanitized);
+        log.info("Verificação de CNPJ {}: {}", sanitized, inUse ? "em uso" : "disponível");
+        return !inUse;
+    }
+
+    public boolean isEmailAvailable(String email) {
+        if (email == null || email.isBlank()) {
+            return true;
+        }
+        boolean inUse = userRepository.existsByEmailIgnoreCase(email.trim());
+        log.info("Verificação de e-mail {}: {}", email.trim(), inUse ? "em uso" : "disponível");
+        return !inUse;
+    }
+
+    public boolean isCpfAvailable(String cpf) {
+        String sanitized = DocumentValidator.sanitize(cpf);
+        if (sanitized == null || sanitized.isBlank()) {
+            return true;
+        }
+        boolean inUse = npoRepository.existsByCpf(sanitized);
+        log.info("Verificação de CPF {}: {}", sanitized, inUse ? "em uso" : "disponível");
+        return !inUse;
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/NpoDocumentService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/NpoDocumentService.java
@@ -3,20 +3,20 @@ package com.vinculohub.backend.service;
 
 import com.vinculohub.backend.exception.DuplicateDocumentException;
 import com.vinculohub.backend.exception.InvalidDocumentException;
+import com.vinculohub.backend.repository.CompanyRepository;
 import com.vinculohub.backend.repository.NpoRepository;
 import com.vinculohub.backend.utils.DocumentValidator;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class NpoDocumentService {
 
     private final NpoRepository npoRepository;
-
-    public NpoDocumentService(NpoRepository npoRepository) {
-        this.npoRepository = npoRepository;
-    }
+    private final CompanyRepository companyRepository;
 
     /**
      * Valida os documentos (CPF e/ou CNPJ) de uma ONG antes do cadastro.
@@ -59,12 +59,12 @@ public class NpoDocumentService {
             }
         }
 
-        // Validar formato e unicidade do CNPJ
+        // Validar formato e unicidade do CNPJ (entre ONG e empresas)
         if (hasCnpj) {
             if (!DocumentValidator.isValidCnpj(sanitizedCnpj)) {
                 throw new InvalidDocumentException("CNPJ informado é inválido.");
             }
-            if (npoRepository.existsByCnpj(sanitizedCnpj)) {
+            if (npoRepository.existsByCnpj(sanitizedCnpj) || companyRepository.existsByCnpj(sanitizedCnpj)) {
                 throw new DuplicateDocumentException(
                         "Já existe uma instituição cadastrada com este CNPJ.");
             }

--- a/frontend/src/api/documentCheck.ts
+++ b/frontend/src/api/documentCheck.ts
@@ -1,0 +1,20 @@
+import { api } from "../services/api";
+
+export async function checkCnpjAvailable(cnpj: string): Promise<boolean> {
+  const digits = cnpj.replace(/\D/g, "");
+  const response = await api.get<{ available: boolean }>(`/public/validate/cnpj/${digits}`);
+  return response.data.available;
+}
+
+export async function checkCpfAvailable(cpf: string): Promise<boolean> {
+  const digits = cpf.replace(/\D/g, "");
+  const response = await api.get<{ available: boolean }>(`/public/validate/cpf/${digits}`);
+  return response.data.available;
+}
+
+export async function checkEmailAvailable(email: string): Promise<boolean> {
+  const response = await api.get<{ available: boolean }>("/public/validate/email", {
+    params: { value: email.trim() },
+  });
+  return response.data.available;
+}

--- a/frontend/src/components/auth/AuthRoleRedirect.tsx
+++ b/frontend/src/components/auth/AuthRoleRedirect.tsx
@@ -6,6 +6,7 @@ import { registerCompany, type CompanyRegistrationPayload } from "../../api/comp
 import { api } from "../../services/api";
 import type { WizardFormData } from "../../types/wizard.types";
 import { logger } from "../../utils/logger";
+import { useToast } from "../../context/ToastContext";
 
 type UserRole = "ADMIN" | "NPO" | "COMPANY" | "UNKNOWN";
 
@@ -35,12 +36,15 @@ type AuthenticatedProfile = {
 const loginCompletedKey = "auth0-login-completed";
 const npoSignupDraftKey = "vinculohub:npo-signup-draft";
 const companySignupDraftKey = "vinculohub:company-signup-draft";
+const npoWizardProgressKey = "vinculohub:npo-wizard-progress";
+const companyWizardProgressKey = "vinculohub:company-wizard-progress";
 const rolesClaim = "https://vinculohub/roles";
 
 export function AuthRoleRedirect() {
   const { getAccessTokenSilently, isAuthenticated, isLoading, user } = useAuth0();
   const location = useLocation();
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   useEffect(() => {
     const shouldRedirect = sessionStorage.getItem(loginCompletedKey) === "true";
@@ -72,6 +76,11 @@ export function AuthRoleRedirect() {
             logger.info("AuthRedirect", "NPO draft submitted successfully");
           } catch (error) {
             logger.error("AuthRedirect", "NPO draft submission failed", getErrorMessage(error));
+            sessionStorage.removeItem(npoSignupDraftKey);
+            sessionStorage.removeItem(npoWizardProgressKey);
+            showToast("Não foi possível concluir o cadastro. Tente novamente.");
+            navigate("/cadastro", { replace: true });
+            return;
           }
         }
 
@@ -83,6 +92,11 @@ export function AuthRoleRedirect() {
             logger.info("AuthRedirect", "Company draft submitted successfully");
           } catch (error) {
             logger.error("AuthRedirect", "Company draft submission failed", getErrorMessage(error));
+            sessionStorage.removeItem(companySignupDraftKey);
+            sessionStorage.removeItem(companyWizardProgressKey);
+            showToast("Não foi possível concluir o cadastro. Tente novamente.");
+            navigate("/cadastro", { replace: true });
+            return;
           }
         }
 
@@ -120,7 +134,7 @@ export function AuthRoleRedirect() {
     }
 
     void redirectByRole();
-  }, [getAccessTokenSilently, isAuthenticated, isLoading, location.pathname, navigate, user]);
+  }, [getAccessTokenSilently, isAuthenticated, isLoading, location.pathname, navigate, showToast, user]);
 
   return null;
 }
@@ -196,6 +210,7 @@ async function submitNpoSignupDraft(token: string, user: unknown) {
   );
 
   sessionStorage.removeItem(npoSignupDraftKey);
+  sessionStorage.removeItem(npoWizardProgressKey);
 }
 
 async function submitCompanySignupDraft(token: string, user: unknown) {
@@ -226,6 +241,7 @@ async function submitCompanySignupDraft(token: string, user: unknown) {
   );
 
   sessionStorage.removeItem(companySignupDraftKey);
+  sessionStorage.removeItem(companyWizardProgressKey);
   logger.info("AuthRedirect", "Company draft removed from sessionStorage");
 }
 

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,12 +1,18 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { useEffect, type ReactNode } from 'react';
+import { Navigate } from 'react-router-dom';
+
+const ROLES_CLAIM = "https://vinculohub/roles";
+
+type UserRole = "ADMIN" | "NPO" | "COMPANY";
 
 type ProtectedRouteProps = {
   children: ReactNode;
+  requiredRole?: UserRole;
 };
 
-export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
+export function ProtectedRoute({ children, requiredRole }: ProtectedRouteProps) {
+  const { isAuthenticated, isLoading, loginWithRedirect, user } = useAuth0();
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -23,6 +29,15 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   if (isLoading || !isAuthenticated) {
     return <p>Carregando...</p>;
+  }
+
+  if (requiredRole) {
+    const rawRoles = (user as Record<string, unknown> | undefined)?.[ROLES_CLAIM];
+    const userRoles: string[] = Array.isArray(rawRoles) ? rawRoles : [];
+    const hasRole = userRoles.some((r) => r.toUpperCase() === requiredRole);
+    if (!hasRole) {
+      return <Navigate to="/" replace />;
+    }
   }
 
   return children;

--- a/frontend/src/context/ToastContext.tsx
+++ b/frontend/src/context/ToastContext.tsx
@@ -1,0 +1,55 @@
+import { Alert, Snackbar } from "@mui/material";
+import { createContext, useCallback, useContext, useState } from "react";
+
+type ToastSeverity = "error" | "warning" | "info" | "success";
+
+type ToastState = {
+  open: boolean;
+  message: string;
+  severity: ToastSeverity;
+};
+
+type ToastContextValue = {
+  showToast: (message: string, severity?: ToastSeverity) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toast, setToast] = useState<ToastState>({
+    open: false,
+    message: "",
+    severity: "error",
+  });
+
+  const showToast = useCallback((message: string, severity: ToastSeverity = "error") => {
+    setToast({ open: true, message, severity });
+  }, []);
+
+  function handleClose(_: React.SyntheticEvent | Event, reason?: string) {
+    if (reason === "clickaway") return;
+    setToast((prev) => ({ ...prev, open: false }));
+  }
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <Snackbar
+        open={toast.open}
+        autoHideDuration={6000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert onClose={handleClose} severity={toast.severity} variant="filled">
+          {toast.message}
+        </Alert>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast deve ser usado dentro de ToastProvider");
+  return ctx;
+}

--- a/frontend/src/hooks/useWizardPersistence.ts
+++ b/frontend/src/hooks/useWizardPersistence.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from "react";
+
+export function useWizardPersistence<T>(
+  key: string,
+  initialState: T,
+): [T, React.Dispatch<React.SetStateAction<T>>, () => void] {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const saved = sessionStorage.getItem(key);
+      if (saved) {
+        return JSON.parse(saved) as T;
+      }
+    } catch {
+      // JSON inválido ou sessionStorage indisponível
+    }
+    return initialState;
+  });
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(key, JSON.stringify(state));
+    } catch {
+      // sessionStorage indisponível ou cota excedida
+    }
+  }, [key, state]);
+
+  const clearPersistence = useCallback(() => {
+    sessionStorage.removeItem(key);
+  }, [key]);
+
+  return [state, setState, clearPersistence];
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import './styles/main.css'
 import { Auth0Provider } from '@auth0/auth0-react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AppRouter } from './router'
+import { ToastProvider } from './context/ToastContext'
 
 const queryClient = new QueryClient()
 
@@ -36,7 +37,9 @@ createRoot(document.getElementById("root")!).render(
       }}
     >
       <QueryClientProvider client={queryClient}>
-        <AppRouter />
+        <ToastProvider>
+          <AppRouter />
+        </ToastProvider>
       </QueryClientProvider>
     </Auth0Provider>
   </StrictMode>,

--- a/frontend/src/pages/CompanyRegistration/registration/index.tsx
+++ b/frontend/src/pages/CompanyRegistration/registration/index.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
+import { useWizardPersistence } from "../../../hooks/useWizardPersistence";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useNavigate } from "react-router-dom";
 import { logger, getApiErrorMessage } from "../../../utils/logger";
+import { useToast } from "../../../context/ToastContext";
+import { checkCnpjAvailable, checkEmailAvailable } from "../../../api/documentCheck";
 import { WizardSteps } from "../../../components/auth/WizardSteps";
 import { AuthRedirectModal } from "../../../components/auth/AuthRedirectModal";
 import { BackLink } from "../../../components/general/BackLink";
@@ -20,31 +23,102 @@ import type { CompanyRegistrationPayload } from "../../../api/company";
 
 const auth0Audience = import.meta.env.VITE_AUTH0_AUDIENCE;
 const companySignupDraftKey = "vinculohub:company-signup-draft";
+const companyWizardProgressKey = "vinculohub:company-wizard-progress";
 
 const LOG = "CompanyRegistration";
+
+type CompanyWizardProgress = {
+  currentStep: number;
+  basicInfo: {
+    name: string;
+    tradeName: string;
+    description: string;
+    cnpj: string;
+  };
+  contactInfo: {
+    zip_code: string;
+    street: string;
+    number: string;
+    complement: string;
+    city: string;
+    state: string;
+    state_code: string;
+    phone: string;
+  };
+  credentials: {
+    email: string;
+  };
+};
 
 export function CompanyRegistrationPage() {
   const { loginWithRedirect } = useAuth0();
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
-  const [currentStep, _setCurrentStep] = useState(2);
-  const setCurrentStep = useCallback((step: number | ((prev: number) => number)) => {
-    _setCurrentStep((prev) => {
-      const next = typeof step === "function" ? step(prev) : step;
-      logger.info(LOG, `Step ${prev} → ${next}`);
-      return next;
+  const [wizardProgress, setWizardProgress, clearWizardProgress] =
+    useWizardPersistence<CompanyWizardProgress>(companyWizardProgressKey, {
+      currentStep: 2,
+      basicInfo: { name: "", tradeName: "", description: "", cnpj: "" },
+      contactInfo: {
+        zip_code: "",
+        street: "",
+        number: "",
+        complement: "",
+        city: "",
+        state: "",
+        state_code: "",
+        phone: "",
+      },
+      credentials: { email: "" },
     });
-  }, []);
+
+  const { basicInfo, contactInfo, credentials } = wizardProgress;
+  const currentStep = wizardProgress.currentStep;
+
+  const setCurrentStep = useCallback((step: number | ((prev: number) => number)) => {
+    setWizardProgress((prev) => {
+      const next = typeof step === "function" ? step(prev.currentStep) : step;
+      logger.info(LOG, `Step ${prev.currentStep} → ${next}`);
+      return { ...prev, currentStep: next };
+    });
+  }, [setWizardProgress]);
+
+  function setBasicInfo(
+    value:
+      | CompanyWizardProgress["basicInfo"]
+      | ((prev: CompanyWizardProgress["basicInfo"]) => CompanyWizardProgress["basicInfo"]),
+  ) {
+    setWizardProgress((prev) => ({
+      ...prev,
+      basicInfo: typeof value === "function" ? value(prev.basicInfo) : value,
+    }));
+  }
+
+  function setContactInfo(
+    value:
+      | CompanyWizardProgress["contactInfo"]
+      | ((prev: CompanyWizardProgress["contactInfo"]) => CompanyWizardProgress["contactInfo"]),
+  ) {
+    setWizardProgress((prev) => ({
+      ...prev,
+      contactInfo: typeof value === "function" ? value(prev.contactInfo) : value,
+    }));
+  }
+
+  function setCredentials(
+    value:
+      | CompanyWizardProgress["credentials"]
+      | ((prev: CompanyWizardProgress["credentials"]) => CompanyWizardProgress["credentials"]),
+  ) {
+    setWizardProgress((prev) => ({
+      ...prev,
+      credentials: typeof value === "function" ? value(prev.credentials) : value,
+    }));
+  }
+
   const [signupError, setSignupError] = useState("");
   const [isRedirectingToAuth0, setIsRedirectingToAuth0] = useState(false);
   const [isAuthRedirectModalOpen, setIsAuthRedirectModalOpen] = useState(false);
-
-  const [basicInfo, setBasicInfo] = useState({
-    name: "",
-    tradeName: "",
-    description: "",
-    cnpj: "",
-  });
 
   const [cnpjError, setCnpjError] = useState("");
 
@@ -70,10 +144,6 @@ export function CompanyRegistrationPage() {
     setContactErrors(errors);
     return valid;
   };
-
-  const [credentials, setCredentials] = useState({
-    email: "",
-  });
 
   const [credentialsErrors, setCredentialsErrors] = useState({
     email: "",
@@ -114,47 +184,30 @@ export function CompanyRegistrationPage() {
     }
   };
 
-  const [contactInfo, setContactInfo] = useState({
-    zip_code: "",
-    street: "",
-    number: "",
-    complement: "",
-    city: "",
-    state: "",
-    state_code: "",
-    phone: "",
-  });
-
   const resetCompanyWizard = () => {
     logger.warn(LOG, "Wizard reset triggered");
+    clearWizardProgress();
     sessionStorage.removeItem(companySignupDraftKey);
-    setCurrentStep(2);
+    setWizardProgress({
+      currentStep: 2,
+      basicInfo: { name: "", tradeName: "", description: "", cnpj: "" },
+      contactInfo: {
+        zip_code: "",
+        street: "",
+        number: "",
+        complement: "",
+        city: "",
+        state: "",
+        state_code: "",
+        phone: "",
+      },
+      credentials: { email: "" },
+    });
     setSignupError("");
     setIsRedirectingToAuth0(false);
-    setBasicInfo({
-      name: "",
-      tradeName: "",
-      description: "",
-      cnpj: "",
-    });
     setCnpjError("");
     setContactErrors({ zip_code: "", number: "" });
-    setCredentials({
-      email: "",
-    });
-    setCredentialsErrors({
-      email: "",
-    });
-    setContactInfo({
-      zip_code: "",
-      street: "",
-      number: "",
-      complement: "",
-      city: "",
-      state: "",
-      state_code: "",
-      phone: "",
-    });
+    setCredentialsErrors({ email: "" });
     navigate("/cadastro", { replace: true });
   };
 
@@ -276,6 +329,20 @@ export function CompanyRegistrationPage() {
     setIsRedirectingToAuth0(true);
 
     try {
+      const cnpjOk = await checkCnpjAvailable(basicInfo.cnpj);
+      if (!cnpjOk) {
+        setIsRedirectingToAuth0(false);
+        showToast("Este CNPJ já está cadastrado na plataforma.");
+        return;
+      }
+
+      const emailOk = await checkEmailAvailable(credentials.email);
+      if (!emailOk) {
+        setIsRedirectingToAuth0(false);
+        showToast("Este e-mail já está cadastrado na plataforma.");
+        return;
+      }
+
       const payload = buildCompanyPayload();
       logger.info(LOG, "Saving company draft to sessionStorage", { cnpj: payload.cnpj, email: payload.email });
       sessionStorage.setItem(
@@ -298,8 +365,9 @@ export function CompanyRegistrationPage() {
       });
     } catch (error) {
       logger.error(LOG, "Auth0 redirect failed", error);
+      sessionStorage.removeItem(companySignupDraftKey);
       setIsRedirectingToAuth0(false);
-      setSignupError("Não foi possível abrir a próxima etapa do cadastro. Tente novamente.");
+      showToast("Não foi possível iniciar o cadastro. Tente novamente.");
     }
   };
 

--- a/frontend/src/pages/LandingPage/Hero.tsx
+++ b/frontend/src/pages/LandingPage/Hero.tsx
@@ -1,5 +1,5 @@
+import { HeroIcon } from "../../assets/landingPage/HeroIcon"
 import { BaseButton } from "../../components/general/BaseButton"
-import { HeroIcon } from "../../assets/LandingPage/HeroIcon"
 
 export function Hero() {
   return (

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useNavigate } from "react-router-dom";
+import { useToast } from "../../context/ToastContext";
+import { checkCnpjAvailable, checkCpfAvailable } from "../../api/documentCheck";
 import { Header } from "../../components/general/Header";
 import { BackLink } from "../../components/general/BackLink";
 import { BaseButton } from "../../components/general/BaseButton";
@@ -10,6 +12,7 @@ import { WizardSignUp } from "../../components/wizard/WizardSignUp";
 import { NpoStepThree } from "../../components/ong/NpoStepThree";
 import { NpoStepFour } from "../../components/ong/NpoStepFour";
 import { stepValidators } from "../../config/wizard.config";
+import { useWizardPersistence } from "../../hooks/useWizardPersistence";
 import type {
   FieldErrors,
   OrganizationType,
@@ -18,6 +21,13 @@ import type {
 
 const auth0Audience = import.meta.env.VITE_AUTH0_AUDIENCE;
 const npoSignupDraftKey = "vinculohub:npo-signup-draft";
+const npoWizardProgressKey = "vinculohub:npo-wizard-progress";
+
+type NpoWizardProgress = {
+  currentStep: number;
+  organizationType: OrganizationType | null;
+  formData: WizardFormData;
+};
 
 const emptyFormData: WizardFormData = {
   nomeInstituicao: "",
@@ -112,10 +122,43 @@ function getSteps({
 export function RegisterPage() {
   const { loginWithRedirect } = useAuth0();
   const navigate = useNavigate();
-  const [currentStep, setCurrentStep] = useState(1);
-  const [organizationType, setOrganizationType] =
-    useState<OrganizationType | null>(null);
-  const [formData, setFormData] = useState<WizardFormData>({ ...emptyFormData });
+  const { showToast } = useToast();
+  const [wizardProgress, setWizardProgress, clearWizardProgress] =
+    useWizardPersistence<NpoWizardProgress>(npoWizardProgressKey, {
+      currentStep: 1,
+      organizationType: null,
+      formData: { ...emptyFormData },
+    });
+
+  const { currentStep, organizationType, formData } = wizardProgress;
+
+  const setCurrentStep = useCallback(
+    (step: number | ((prev: number) => number)) => {
+      setWizardProgress((prev) => ({
+        ...prev,
+        currentStep: typeof step === "function" ? step(prev.currentStep) : step,
+      }));
+    },
+    [setWizardProgress],
+  );
+
+  const setOrganizationType = useCallback(
+    (type: OrganizationType | null) => {
+      setWizardProgress((prev) => ({ ...prev, organizationType: type }));
+    },
+    [setWizardProgress],
+  );
+
+  const setFormData = useCallback(
+    (data: WizardFormData | ((prev: WizardFormData) => WizardFormData)) => {
+      setWizardProgress((prev) => ({
+        ...prev,
+        formData: typeof data === "function" ? data(prev.formData) : data,
+      }));
+    },
+    [setWizardProgress],
+  );
+
   const [errors, setErrors] = useState<FieldErrors>({});
   const [isAuthRedirectModalOpen, setIsAuthRedirectModalOpen] = useState(false);
 
@@ -128,7 +171,7 @@ export function RegisterPage() {
         setFormData,
         errors,
       }),
-    [organizationType, formData, errors],
+    [organizationType, formData, errors, setOrganizationType, setFormData],
   );
 
   const totalSteps = steps.length;
@@ -141,20 +184,40 @@ export function RegisterPage() {
   }, [currentStep, navigate, organizationType]);
 
   async function handleNpoSignup() {
-    sessionStorage.setItem(
-      npoSignupDraftKey,
-      JSON.stringify({ currentStep, organizationType, formData }),
-    );
+    try {
+      if (formData.cnpj) {
+        const cnpjOk = await checkCnpjAvailable(formData.cnpj);
+        if (!cnpjOk) {
+          showToast("Este CNPJ já está cadastrado na plataforma.");
+          return;
+        }
+      }
+      if (formData.cpf) {
+        const cpfOk = await checkCpfAvailable(formData.cpf);
+        if (!cpfOk) {
+          showToast("Este CPF já está cadastrado na plataforma.");
+          return;
+        }
+      }
 
-    await loginWithRedirect({
-      appState: { returnTo: "/ong/dashboard" },
-      authorizationParams: {
-        audience: auth0Audience,
-        role: "NPO",
-        screen_hint: "signup",
-        ui_locales: "pt-BR",
-      },
-    });
+      sessionStorage.setItem(
+        npoSignupDraftKey,
+        JSON.stringify({ currentStep, organizationType, formData }),
+      );
+
+      await loginWithRedirect({
+        appState: { returnTo: "/ong/dashboard" },
+        authorizationParams: {
+          audience: auth0Audience,
+          role: "NPO",
+          screen_hint: "signup",
+          ui_locales: "pt-BR",
+        },
+      });
+    } catch {
+      sessionStorage.removeItem(npoSignupDraftKey);
+      showToast("Não foi possível iniciar o cadastro. Tente novamente.");
+    }
   }
 
   function openNpoSignupRedirectNotice() {
@@ -192,10 +255,9 @@ export function RegisterPage() {
   }
 
   function handleResetToFirstStep() {
+    clearWizardProgress();
     sessionStorage.removeItem(npoSignupDraftKey);
-    setCurrentStep(1);
-    setOrganizationType(null);
-    setFormData({ ...emptyFormData });
+    setWizardProgress({ currentStep: 1, organizationType: null, formData: { ...emptyFormData } });
     setErrors({});
     navigate("/cadastro", { replace: true });
   }

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -20,7 +20,7 @@ export const AppRouter = () => (
       <Route
         path="/admin/dashboard"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute requiredRole="ADMIN">
             <RoleHomePage
               title="Painel administrativo"
               description="Gerencie usuários, organizações e configurações da plataforma."
@@ -31,7 +31,7 @@ export const AppRouter = () => (
       <Route
         path="/ong/dashboard"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute requiredRole="NPO">
             <RoleHomePage
               title="Painel da ONG"
               description="Acompanhe seu cadastro, projetos e oportunidades para sua organização."
@@ -42,7 +42,7 @@ export const AppRouter = () => (
       <Route
         path="/empresa/dashboard"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute requiredRole="COMPANY">
             <RoleHomePage
               title="Painel da empresa"
               description="Encontre projetos, acompanhe parcerias e gerencie seu perfil institucional."


### PR DESCRIPTION
## Issue Link
Closes #

## Description
Correções P0 e P1 identificadas na revisão de código da sprint 1:

**Wizard persistence (1.1)**
- Hook `useWizardPersistence<T>` persiste `currentStep` + dados do formulário no `sessionStorage` a cada mudança e reidrata na montagem. Chaves: `vinculohub:npo-wizard-progress` e `vinculohub:company-wizard-progress`. `AuthRoleRedirect` limpa as chaves após submissão bem-sucedida.

**Erros de cadastro engolidos + contas lixo no Auth0 (1.2)**
- `AuthRoleRedirect`: falha no POST agora remove draft + progress do `sessionStorage`, exibe toast via `ToastContext` e redireciona para `/cadastro`. Usuário não chega ao dashboard sem conta no banco.
- Validações movidas para **antes** do `loginWithRedirect` via endpoints públicos, impedindo criação de conta no Auth0 para dados inválidos.

**Validação cruzada de CPF/CNPJ entre ONG e Empresa (1.3)**
- `DocumentCheckService` + `DocumentCheckController` com `GET /public/validate/cnpj`, `/cpf`, `/email` consultando ambas as tabelas.
- `NpoDocumentService` e `CompanyService` atualizados para checar cross-table.
- Frontend aborta o fluxo com toast se documento ou email já em uso.

**CNPJ não normalizado (1.4)**
- `CompanyService` usa `DocumentValidator.sanitize()` antes do `existsByCnpj` e persiste só dígitos.

**Validação de email no cadastro de empresa (3.6)**
- `checkEmailAvailable()` chamado antes do `loginWithRedirect` na empresa.

**Role enforcement no backend (2.1)**
- `POST /api/npo-accounts`: `@PreAuthorize("!hasRole('company') && !hasRole('admin')")`
- `POST /api/company-accounts`: `@PreAuthorize("!hasRole('npo') && !hasRole('admin')")`
- `GET /api/me` (AuthTestController): `@PreAuthorize("hasRole('admin')")`

**Role check no frontend (2.2)**
- `ProtectedRoute` ganhou prop `requiredRole?: "ADMIN" | "NPO" | "COMPANY"`. Lê roles do claim `https://vinculohub/roles` no `user` object do Auth0. Redireciona para `/` se sem permissão.
- Router atualizado: `/admin/dashboard` → `ADMIN`, `/ong/dashboard` → `NPO`, `/empresa/dashboard` → `COMPANY`.

## Task Notes
- TOCTOU entre pre-validação e criação da conta é reconhecido como aceitável para este contexto.
- Feedback inline por campo (erro embaixo do input) permanece como melhoria futura

## Screenshots
N/A