### PR TITLE
Fix/clean débito técnico

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -128,6 +128,22 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+				<configuration>
+					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.36</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>

--- a/backend/src/main/java/com/vinculohub/backend/dto/NpoFirstProjectSignupRequest.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/NpoFirstProjectSignupRequest.java
@@ -1,0 +1,8 @@
+/* (C)2026 */
+package com.vinculohub.backend.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record NpoFirstProjectSignupRequest(
+        String name, String description, BigDecimal capital, List<String> ods) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/NpoInstitutionalSignupRequest.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/NpoInstitutionalSignupRequest.java
@@ -12,4 +12,5 @@ public record NpoInstitutionalSignupRequest(
         Boolean environmental,
         Boolean social,
         Boolean governance,
-        AddressSignupRequest address) {}
+        AddressSignupRequest address,
+        NpoFirstProjectSignupRequest firstProject) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/NpoInstitutionalSignupResponse.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/NpoInstitutionalSignupResponse.java
@@ -2,4 +2,4 @@
 package com.vinculohub.backend.dto;
 
 public record NpoInstitutionalSignupResponse(
-        Integer userId, Integer npoId, String email, boolean accessReleased) {}
+        Integer userId, Integer npoId, Long projectId, String email, boolean accessReleased) {}

--- a/backend/src/main/java/com/vinculohub/backend/model/Project.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/Project.java
@@ -1,0 +1,73 @@
+/* (C)2026 */
+package com.vinculohub.backend.model;
+
+import com.vinculohub.backend.model.enums.ProjectStatus;
+import jakarta.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "project")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "npo_id", nullable = false)
+    private Npo npo;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private ProjectStatus status = ProjectStatus.DRAFT;
+
+    @Column(name = "budget_needed", precision = 15, scale = 2)
+    private BigDecimal budgetNeeded;
+
+    @Column(name = "invested_amount", precision = 15, scale = 2)
+    private BigDecimal investedAmount;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "project_ods", joinColumns = @JoinColumn(name = "project_id"))
+    @Column(name = "ods_code", nullable = false)
+    @Builder.Default
+    private Set<Integer> odsCodes = new LinkedHashSet<>();
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/backend/src/main/java/com/vinculohub/backend/model/enums/ProjectStatus.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/enums/ProjectStatus.java
@@ -1,0 +1,9 @@
+/* (C)2026 */
+package com.vinculohub.backend.model.enums;
+
+public enum ProjectStatus {
+    DRAFT,
+    ACTIVE,
+    COMPLETED,
+    CANCELLED
+}

--- a/backend/src/main/java/com/vinculohub/backend/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/vinculohub/backend/repository/ProjectRepository.java
@@ -1,0 +1,12 @@
+/* (C)2026 */
+package com.vinculohub.backend.repository;
+
+import com.vinculohub.backend.model.Project;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    List<Project> findAllByNpoId(Long npoId);
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/NpoAccountService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/NpoAccountService.java
@@ -7,6 +7,7 @@ import com.vinculohub.backend.dto.NpoInstitutionalSignupResponse;
 import com.vinculohub.backend.exception.DuplicateLoginException;
 import com.vinculohub.backend.model.Address;
 import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
 import com.vinculohub.backend.model.User;
 import com.vinculohub.backend.model.enums.NpoSize;
 import com.vinculohub.backend.model.enums.UserType;
@@ -22,16 +23,22 @@ public class NpoAccountService {
 
     private final UserRepository userRepository;
     private final NpoService npoService;
+    private final ProjectValidationService projectValidationService;
+    private final ProjectService projectService;
     private final NpoDocumentService npoDocumentService;
     private final NpoEsgService npoEsgService;
 
     public NpoAccountService(
             UserRepository userRepository,
             NpoService npoService,
+            ProjectValidationService projectValidationService,
+            ProjectService projectService,
             NpoDocumentService npoDocumentService,
             NpoEsgService npoEsgService) {
         this.userRepository = userRepository;
         this.npoService = npoService;
+        this.projectValidationService = projectValidationService;
+        this.projectService = projectService;
         this.npoDocumentService = npoDocumentService;
         this.npoEsgService = npoEsgService;
     }
@@ -58,6 +65,7 @@ public class NpoAccountService {
         npoDocumentService.validateDocuments(request.cpf(), request.cnpj());
         npoEsgService.validateEsgSelection(
                 request.environmental(), request.social(), request.governance());
+        projectValidationService.validateFirstProject(request.firstProject());
 
         User savedUser =
                 userRepository.save(
@@ -84,8 +92,14 @@ public class NpoAccountService {
 
         Npo savedNpo = npoService.saveWithAddress(npo, toAddressOrNull(request.address()));
 
+        Project savedProject = projectService.createFirstProject(savedNpo, request.firstProject());
+
         return new NpoInstitutionalSignupResponse(
-                savedUser.getId(), savedNpo.getId(), savedUser.getEmail(), true);
+                savedUser.getId(),
+                savedNpo.getId(),
+                savedProject.getId(),
+                savedUser.getEmail(),
+                true);
     }
 
     private static String normalizeEmail(String value) {

--- a/backend/src/main/java/com/vinculohub/backend/service/OdsMapper.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/OdsMapper.java
@@ -1,0 +1,32 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OdsMapper {
+
+    public Set<Integer> normalizeCodes(List<String> ods) {
+        if (ods == null) {
+            return Set.of();
+        }
+
+        Set<Integer> result = new LinkedHashSet<>();
+        for (String value : ods) {
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException("ODS inválido.");
+            }
+
+            try {
+                result.add(Integer.parseInt(value.trim()));
+            } catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("ODS inválido.", ex);
+            }
+        }
+
+        return result;
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
@@ -1,0 +1,58 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import com.vinculohub.backend.dto.NpoFirstProjectSignupRequest;
+import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.repository.ProjectRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final OdsMapper odsMapper;
+
+    public ProjectService(ProjectRepository projectRepository, OdsMapper odsMapper) {
+        this.projectRepository = projectRepository;
+        this.odsMapper = odsMapper;
+    }
+
+    public Project save(Project project) {
+        if (project == null) {
+            throw new IllegalArgumentException("O projeto não pode ser nulo.");
+        }
+        return projectRepository.save(project);
+    }
+
+    public Project createFirstProject(Npo npo, NpoFirstProjectSignupRequest request) {
+        if (npo == null) {
+            throw new IllegalArgumentException("A ONG vinculada ao projeto é obrigatória.");
+        }
+
+        if (request == null) {
+            throw new IllegalArgumentException("Os dados do primeiro projeto são obrigatórios.");
+        }
+
+        Project project =
+                Project.builder()
+                        .npo(npo)
+                        .title(requireText(request.name(), "Nome do projeto é obrigatório."))
+                        .description(
+                                requireText(
+                                        request.description(),
+                                        "Descrição do projeto é obrigatória."))
+                        .budgetNeeded(request.capital())
+                        .odsCodes(odsMapper.normalizeCodes(request.ods()))
+                        .build();
+
+        return save(project);
+    }
+
+    private static String requireText(String value, String message) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(message);
+        }
+        return value.trim();
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/ProjectValidationService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/ProjectValidationService.java
@@ -1,0 +1,46 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import com.vinculohub.backend.dto.NpoFirstProjectSignupRequest;
+import java.math.BigDecimal;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProjectValidationService {
+
+    public void validateFirstProject(NpoFirstProjectSignupRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("Os dados do primeiro projeto são obrigatórios.");
+        }
+
+        requireText(request.name(), "Nome do projeto é obrigatório.");
+        requireText(request.description(), "Descrição do projeto é obrigatória.");
+        validateCapital(request.capital());
+        validateOds(request.ods());
+    }
+
+    private static void validateCapital(BigDecimal capital) {
+        if (capital != null && capital.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("A meta de captação não pode ser negativa.");
+        }
+    }
+
+    private static void validateOds(List<String> ods) {
+        if (ods == null || ods.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "É obrigatório informar ao menos um ODS para o projeto.");
+        }
+
+        for (String value : ods) {
+            requireText(value, "ODS inválido.");
+        }
+    }
+
+    private static String requireText(String value, String message) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(message);
+        }
+        return value.trim();
+    }
+}

--- a/backend/src/main/resources/db/migration/V1.3__create_project_table.sql
+++ b/backend/src/main/resources/db/migration/V1.3__create_project_table.sql
@@ -1,0 +1,95 @@
+-- Alinha a tabela project criada em V1__init.sql com o model JPA atual
+
+-- Solta FKs que dependem de project.id
+ALTER TABLE IF EXISTS "document"
+    DROP CONSTRAINT IF EXISTS document_project_id_fkey;
+
+ALTER TABLE IF EXISTS "project_sdg"
+    DROP CONSTRAINT IF EXISTS project_sdg_project_id_fkey;
+
+ALTER TABLE IF EXISTS "company_project"
+    DROP CONSTRAINT IF EXISTS company_project_project_id_fkey;
+
+ALTER TABLE IF EXISTS "project_ods"
+    DROP CONSTRAINT IF EXISTS fk_project_ods_project;
+
+-- Alinha a tabela project
+ALTER TABLE "project"
+    ALTER COLUMN "id" TYPE BIGINT,
+    ALTER COLUMN "title" SET NOT NULL,
+    ALTER COLUMN "description" TYPE VARCHAR(1000),
+    ALTER COLUMN "description" SET NOT NULL,
+    ALTER COLUMN "npo_id" SET NOT NULL;
+
+-- status sai do enum legado e vira VARCHAR(20), compatível com @Enumerated(EnumType.STRING)
+ALTER TABLE "project"
+    ALTER COLUMN "status" DROP DEFAULT;
+
+ALTER TABLE "project"
+    ALTER COLUMN "status" TYPE VARCHAR(20)
+    USING CASE
+        WHEN "status"::text = 'active' THEN 'ACTIVE'
+        WHEN "status"::text = 'completed' THEN 'COMPLETED'
+        WHEN "status"::text = 'cancelled' THEN 'CANCELLED'
+        ELSE 'DRAFT'
+    END;
+
+UPDATE "project"
+SET "status" = 'DRAFT'
+WHERE "status" IS NULL;
+
+ALTER TABLE "project"
+    ALTER COLUMN "status" SET DEFAULT 'DRAFT',
+    ALTER COLUMN "status" SET NOT NULL;
+
+-- Colunas que referenciam project.id agora precisam acompanhar BIGINT
+ALTER TABLE IF EXISTS "document"
+    ALTER COLUMN "project_id" TYPE BIGINT USING "project_id"::BIGINT;
+
+ALTER TABLE IF EXISTS "project_sdg"
+    ALTER COLUMN "project_id" TYPE BIGINT USING "project_id"::BIGINT;
+
+ALTER TABLE IF EXISTS "company_project"
+    ALTER COLUMN "project_id" TYPE BIGINT USING "project_id"::BIGINT;
+
+-- Tabela da ElementCollection do Project
+CREATE TABLE IF NOT EXISTS "project_ods" (
+    "project_id" BIGINT NOT NULL,
+    "ods_code" INTEGER NOT NULL,
+    CONSTRAINT "fk_project_ods_project"
+        FOREIGN KEY ("project_id")
+        REFERENCES "project" ("id")
+        ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uk_project_ods_project_code"
+    ON "project_ods" ("project_id", "ods_code");
+
+-- Índices esperados para project
+CREATE INDEX IF NOT EXISTS "idx_project_npo_id"
+    ON "project" ("npo_id");
+
+CREATE INDEX IF NOT EXISTS "idx_project_deleted_at"
+    ON "project" ("deleted_at");
+
+CREATE INDEX IF NOT EXISTS "idx_project_status"
+    ON "project" ("status");
+
+-- Recria FKs que apontam para project.id
+ALTER TABLE IF EXISTS "document"
+    ADD CONSTRAINT "document_project_id_fkey"
+    FOREIGN KEY ("project_id")
+    REFERENCES "project" ("id")
+    DEFERRABLE INITIALLY IMMEDIATE;
+
+ALTER TABLE IF EXISTS "project_sdg"
+    ADD CONSTRAINT "project_sdg_project_id_fkey"
+    FOREIGN KEY ("project_id")
+    REFERENCES "project" ("id")
+    DEFERRABLE INITIALLY IMMEDIATE;
+
+ALTER TABLE IF EXISTS "company_project"
+    ADD CONSTRAINT "company_project_project_id_fkey"
+    FOREIGN KEY ("project_id")
+    REFERENCES "project" ("id")
+    DEFERRABLE INITIALLY IMMEDIATE;

--- a/backend/src/test/java/com/vinculohub/backend/repository/ProjectRepositoryTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/repository/ProjectRepositoryTest.java
@@ -1,0 +1,57 @@
+/* (C)2026 */
+package com.vinculohub.backend.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.vinculohub.backend.database.AbstractIntegrationTest;
+import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.model.enums.NpoSize;
+import com.vinculohub.backend.model.enums.ProjectStatus;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+class ProjectRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private NpoRepository npoRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Test
+    @DisplayName("Deve persistir projeto vinculado a uma ONG")
+    void shouldPersistProjectWithNpoRelationship() {
+        Npo npo = npoRepository.save(
+            Npo.builder()
+                .name("ONG Exemplo")
+                .npoSize(NpoSize.small)
+                .environmental(true)
+                .build()
+        );
+
+        Project project = projectRepository.save(
+            Project.builder()
+                .npo(npo)
+                .title("Projeto Exemplo")
+                .description("Projeto piloto para validar o mapeamento.")
+                .build()
+        );
+
+        assertNotNull(project.getId());
+        assertEquals(ProjectStatus.DRAFT, project.getStatus());
+
+        List<Project> projects = projectRepository.findAllByNpoId(
+            Long.valueOf(npo.getId())
+        );
+
+        assertEquals(1, projects.size());
+        assertEquals(npo.getId(), projects.get(0).getNpo().getId());
+        assertEquals("Projeto Exemplo", projects.get(0).getTitle());
+    }
+}

--- a/backend/src/test/java/com/vinculohub/backend/service/NpoAccountServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/NpoAccountServiceTest.java
@@ -8,13 +8,17 @@ import static org.mockito.Mockito.*;
 import com.vinculohub.backend.dto.AddressSignupRequest;
 import com.vinculohub.backend.dto.NpoInstitutionalSignupRequest;
 import com.vinculohub.backend.dto.NpoInstitutionalSignupResponse;
+import com.vinculohub.backend.dto.NpoFirstProjectSignupRequest;
 import com.vinculohub.backend.exception.DuplicateLoginException;
 import com.vinculohub.backend.model.Address;
 import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
 import com.vinculohub.backend.model.User;
 import com.vinculohub.backend.model.enums.NpoSize;
 import com.vinculohub.backend.model.enums.UserType;
 import com.vinculohub.backend.repository.UserRepository;
+import java.math.BigDecimal;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +34,10 @@ class NpoAccountServiceTest {
     @Mock private UserRepository userRepository;
 
     @Mock private NpoService npoService;
+
+    @Mock private ProjectValidationService projectValidationService;
+
+    @Mock private ProjectService projectService;
 
     @Mock private NpoDocumentService npoDocumentService;
 
@@ -60,6 +68,13 @@ class NpoAccountServiceTest {
                             npo.setId(20);
                             return npo;
                         });
+        when(projectService.createFirstProject(any(Npo.class), any(NpoFirstProjectSignupRequest.class)))
+                .thenAnswer(
+                        invocation -> {
+                            Project project = new Project();
+                            project.setId(30L);
+                            return project;
+                        });
 
         NpoInstitutionalSignupResponse response =
                 npoAccountService.registerInstitutionalAccount(
@@ -68,9 +83,13 @@ class NpoAccountServiceTest {
         ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
         ArgumentCaptor<Npo> npoCaptor = ArgumentCaptor.forClass(Npo.class);
         ArgumentCaptor<Address> addressCaptor = ArgumentCaptor.forClass(Address.class);
+        ArgumentCaptor<NpoFirstProjectSignupRequest> projectRequestCaptor =
+                ArgumentCaptor.forClass(NpoFirstProjectSignupRequest.class);
 
         verify(userRepository).save(userCaptor.capture());
         verify(npoService).saveWithAddress(npoCaptor.capture(), addressCaptor.capture());
+        verify(projectValidationService).validateFirstProject(projectRequestCaptor.capture());
+        verify(projectService).createFirstProject(eq(npoCaptor.getValue()), eq(request.firstProject()));
         verify(npoDocumentService).validateDocuments("529.982.247-25", null);
         verify(npoEsgService).validateEsgSelection(true, false, false);
 
@@ -94,8 +113,15 @@ class NpoAccountServiceTest {
 
         assertEquals(10, response.userId());
         assertEquals(20, response.npoId());
+        assertEquals(30L, response.projectId());
         assertEquals("contato@ong.org", response.email());
         assertTrue(response.accessReleased());
+
+        NpoFirstProjectSignupRequest savedProjectRequest = projectRequestCaptor.getValue();
+        assertEquals("Projeto Inicial", savedProjectRequest.name());
+        assertEquals("Projeto piloto", savedProjectRequest.description());
+        assertEquals(new BigDecimal("1000.00"), savedProjectRequest.capital());
+        assertEquals(List.of("1", "2"), savedProjectRequest.ods());
     }
 
     @Test
@@ -142,6 +168,11 @@ class NpoAccountServiceTest {
                 false,
                 false,
                 new AddressSignupRequest(
-                        "São Paulo", "SP", "São Paulo", "Rua A", "123", "Sala 1", "01000-000"));
+                        "São Paulo", "SP", "São Paulo", "Rua A", "123", "Sala 1", "01000-000"),
+                new NpoFirstProjectSignupRequest(
+                        "Projeto Inicial",
+                        "Projeto piloto",
+                        new BigDecimal("1000.00"),
+                        List.of("1", "2")));
     }
 }

--- a/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
@@ -1,0 +1,73 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vinculohub.backend.dto.NpoFirstProjectSignupRequest;
+import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.repository.ProjectRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceTest {
+
+    @Mock
+    private ProjectRepository projectRepository;
+
+    @Mock
+    private OdsMapper odsMapper;
+
+    @InjectMocks
+    private ProjectService projectService;
+
+    @Test
+    void shouldCreateFirstProjectWithMappedFields() {
+        Npo npo = Npo.builder().id(20).name("ONG Exemplo").build();
+
+        NpoFirstProjectSignupRequest request = new NpoFirstProjectSignupRequest(
+            "Projeto Inicial",
+            "Descrição do projeto inicial",
+            new BigDecimal("1000.00"),
+            List.of("1", "2")
+        );
+
+        when(odsMapper.normalizeCodes(List.of("1", "2"))).thenReturn(
+            Set.of(1, 2)
+        );
+
+        when(projectRepository.save(any(Project.class))).thenAnswer(
+            invocation -> {
+                Project project = invocation.getArgument(0);
+                project.setId(30L);
+                return project;
+            }
+        );
+
+        Project savedProject = projectService.createFirstProject(npo, request);
+
+        assertEquals(30L, savedProject.getId());
+        assertNotNull(savedProject.getNpo());
+        assertEquals(20, savedProject.getNpo().getId());
+        assertEquals("Projeto Inicial", savedProject.getTitle());
+        assertEquals(
+            "Descrição do projeto inicial",
+            savedProject.getDescription()
+        );
+        assertEquals(new BigDecimal("1000.00"), savedProject.getBudgetNeeded());
+        assertEquals(Set.of(1, 2), savedProject.getOdsCodes());
+
+        verify(odsMapper).normalizeCodes(List.of("1", "2"));
+    }
+}

--- a/frontend/src/components/auth/AuthRoleRedirect.test.tsx
+++ b/frontend/src/components/auth/AuthRoleRedirect.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AuthRoleRedirect } from "./AuthRoleRedirect";
+
+const mocks = vi.hoisted(() => ({
+  showToastMock: vi.fn(),
+  getAccessTokenSilentlyMock: vi.fn(),
+  navigateMock: vi.fn(),
+  apiPostMock: vi.fn(),
+}));
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: () => ({
+    getAccessTokenSilently: mocks.getAccessTokenSilentlyMock,
+    isAuthenticated: true,
+    isLoading: false,
+    user: { email: "teste@exemplo.com" },
+  }),
+}));
+
+vi.mock("../../context/ToastContext", () => ({
+  useToast: () => ({ showToast: mocks.showToastMock }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+
+  return {
+    ...actual,
+    useNavigate: () => mocks.navigateMock,
+  };
+});
+
+vi.mock("../../services/api", () => ({
+  api: {
+    get: vi.fn(),
+    post: mocks.apiPostMock,
+  },
+}));
+
+describe("AuthRoleRedirect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    sessionStorage.setItem("auth0-login-completed", "true");
+    sessionStorage.setItem(
+      "vinculohub:npo-signup-draft",
+      JSON.stringify({
+        formData: {
+          nomeInstituicao: "Instituto Teste",
+          email: "teste@exemplo.com",
+          senha: "Abcd1234",
+          confirmarSenha: "Abcd1234",
+          cnpj: "",
+          razaoSocial: "",
+          cpf: "529.982.247-25",
+          porteOng: "pequena",
+          resumoInstitucional: "",
+          esg: ["ambiental"],
+          zipCode: "",
+          street: "",
+          streetNumber: "",
+          complement: "",
+          city: "",
+          state: "",
+          stateCode: "",
+          phone: "",
+        },
+      }),
+    );
+    mocks.getAccessTokenSilentlyMock.mockResolvedValue("token");
+    mocks.apiPostMock.mockRejectedValue(
+      Object.assign(new Error("Service unavailable"), {
+        isAxiosError: true,
+        response: { status: 503 },
+      }),
+    );
+  });
+
+  it("mostra serviço indisponível quando o envio falha por erro 5xx", async () => {
+    render(
+      <MemoryRouter initialEntries={["/cadastro"]}>
+        <AuthRoleRedirect />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.showToastMock).toHaveBeenCalledWith("Serviço indisponível");
+    });
+  });
+});

--- a/frontend/src/components/auth/AuthRoleRedirect.tsx
+++ b/frontend/src/components/auth/AuthRoleRedirect.tsx
@@ -76,9 +76,13 @@ export function AuthRoleRedirect() {
             logger.info("AuthRedirect", "NPO draft submitted successfully");
           } catch (error) {
             logger.error("AuthRedirect", "NPO draft submission failed", getErrorMessage(error));
-            sessionStorage.removeItem(npoSignupDraftKey);
-            sessionStorage.removeItem(npoWizardProgressKey);
-            showToast("Não foi possível concluir o cadastro. Tente novamente.");
+            if (isServiceUnavailableError(error)) {
+              showToast("Serviço indisponível");
+            } else {
+              sessionStorage.removeItem(npoSignupDraftKey);
+              sessionStorage.removeItem(npoWizardProgressKey);
+              showToast("Não foi possível concluir o cadastro. Tente novamente.");
+            }
             navigate("/cadastro", { replace: true });
             return;
           }
@@ -146,6 +150,18 @@ function getErrorMessage(error: unknown) {
   }
 
   return String(error);
+}
+
+function isServiceUnavailableError(error: unknown) {
+  if (!axios.isAxiosError(error)) {
+    return false;
+  }
+
+  if (!error.response) {
+    return true;
+  }
+
+  return error.response.status >= 500 && error.response.status < 600;
 }
 
 async function getAuthenticatedProfile(token: string) {

--- a/frontend/src/pages/RegisterPage/index.test.tsx
+++ b/frontend/src/pages/RegisterPage/index.test.tsx
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { RegisterPage } from "./index";
+
+const loginWithRedirectMock = vi.fn();
+const checkCpfAvailableMock = vi.fn();
+const checkCnpjAvailableMock = vi.fn();
+const showToastMock = vi.fn();
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: () => ({
+    isAuthenticated: false,
+    isLoading: false,
+    loginWithRedirect: loginWithRedirectMock,
+    logout: vi.fn(),
+    getAccessTokenSilently: vi.fn(),
+    user: null,
+  }),
+}));
+
+vi.mock("../../api/documentCheck", () => ({
+  checkCpfAvailable: (...args: unknown[]) => checkCpfAvailableMock(...args),
+  checkCnpjAvailable: (...args: unknown[]) => checkCnpjAvailableMock(...args),
+}));
+
+vi.mock("../../hooks/useZipCode", () => ({
+  useZipCode: () => ({ data: undefined, isFetching: false, error: undefined }),
+}));
+
+vi.mock("../../context/ToastContext", () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/cadastro"]}>
+      <RegisterPage />
+    </MemoryRouter>,
+  );
+}
+
+async function reachNpoFinalStep(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /Cadastro como ONG/i }));
+  await user.click(screen.getByRole("button", { name: /Próximo/i }));
+
+  await user.type(await screen.findByLabelText(/Nome da Instituição/i), "Instituto Teste");
+  await user.type(screen.getByLabelText(/CPF do Responsável/i), "529.982.247-25");
+  await user.selectOptions(screen.getByLabelText(/Porte da ONG/i), "pequena");
+  await user.click(screen.getByRole("button", { name: /Ambiental/i }));
+  await user.click(screen.getByRole("button", { name: /Próximo/i }));
+
+  await user.type(await screen.findByLabelText(/CEP/i), "01310-100");
+  await user.type(screen.getByLabelText(/Número/i), "123");
+  await user.click(screen.getByRole("button", { name: /Finalizar/i }));
+}
+
+describe("RegisterPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    checkCpfAvailableMock.mockResolvedValue(true);
+    checkCnpjAvailableMock.mockResolvedValue(true);
+  });
+
+  it("mostra loading no modal enquanto conclui o cadastro da ONG", async () => {
+    const user = userEvent.setup();
+    let resolveLogin: (() => void) | null = null;
+
+    loginWithRedirectMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveLogin = resolve;
+      }),
+    );
+
+    renderPage();
+    await reachNpoFinalStep(user);
+
+    await user.click(screen.getByRole("button", { name: /Finalizar/i }));
+    await user.click(screen.getByRole("button", { name: /Continuar/i }));
+
+    expect(
+      await screen.findByRole("button", { name: /Redirecionando.../i }),
+    ).toBeDisabled();
+
+    resolveLogin?.();
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /Redirecionando.../i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/RegisterPage/index.tsx
+++ b/frontend/src/pages/RegisterPage/index.tsx
@@ -161,6 +161,7 @@ export function RegisterPage() {
 
   const [errors, setErrors] = useState<FieldErrors>({});
   const [isAuthRedirectModalOpen, setIsAuthRedirectModalOpen] = useState(false);
+  const [isSubmittingNpo, setIsSubmittingNpo] = useState(false);
 
   const steps = useMemo(
     () =>
@@ -217,6 +218,17 @@ export function RegisterPage() {
     } catch {
       sessionStorage.removeItem(npoSignupDraftKey);
       showToast("Não foi possível iniciar o cadastro. Tente novamente.");
+    }
+  }
+
+  async function handleConfirmNpoSignup() {
+    setIsSubmittingNpo(true);
+
+    try {
+      await handleNpoSignup();
+    } finally {
+      setIsSubmittingNpo(false);
+      setIsAuthRedirectModalOpen(false);
     }
   }
 
@@ -292,10 +304,10 @@ export function RegisterPage() {
         title="Você será redirecionado para concluir o acesso"
         description="Na próxima etapa, abriremos o ambiente seguro de autenticação para criar sua conta e concluir a entrada no VinculoHubPortal."
         confirmLabel="Continuar"
+        isLoading={isSubmittingNpo}
         onCancel={() => setIsAuthRedirectModalOpen(false)}
         onConfirm={() => {
-          setIsAuthRedirectModalOpen(false);
-          void handleNpoSignup();
+          void handleConfirmNpoSignup();
         }}
       />
     </div>


### PR DESCRIPTION
## Issue Link
Closes #23 #127 

## Description

backend: add atomic NPO signup with first project

- add project domain, validation, and ODS mapping
- extend NPO signup contract to carry the first project and return its id
- persist user, NPO, and first project in a single transaction
- configure Maven compiler for Lombok annotation processing
- update unit tests for the new signup flow

## Task Notes

Implementação limpa, a partir da branch development.

## Screenshots

Step 1
<img width="984" height="760" alt="image" src="https://github.com/user-attachments/assets/dd3f6eed-7f90-4322-8dc1-81b0a33bedc7" />
Step 2
<img width="1012" height="801" alt="image" src="https://github.com/user-attachments/assets/bda5e55f-8e41-4ef0-8455-6b2c91d83a71" />
<img width="1003" height="714" alt="image" src="https://github.com/user-attachments/assets/55e00e18-f69e-42ac-82f8-55ffc479302f" />
Step 3
<img width="960" height="166" alt="image" src="https://github.com/user-attachments/assets/ca79e461-5aad-4abe-8361-78d81cdc40da" />
<img width="979" height="119" alt="image" src="https://github.com/user-attachments/assets/f854d4ae-02c3-40ef-a47f-d1aab48bcb63" />
