### PR TITLE
(US-06) Dashboard Empresas

### DIFF
--- a/frontend/src/components/auth/AuthRoleRedirect.test.tsx
+++ b/frontend/src/components/auth/AuthRoleRedirect.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { AuthRoleRedirect } from "./AuthRoleRedirect";
+import { api } from "../../services/api";
 
 const mocks = vi.hoisted(() => ({
   showToastMock: vi.fn(),
@@ -143,5 +144,53 @@ describe("AuthRoleRedirect", () => {
     const [, payload] = mocks.apiPostMock.mock.calls[0];
     expect(payload.firstProject.capital).toBeNull();
     expect(payload.firstProject.ods).toEqual(["1"]);
+  });
+});
+
+describe("AuthRoleRedirect — fix de deep-link (returnTo)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    sessionStorage.setItem("auth0-login-completed", "true");
+    mocks.getAccessTokenSilentlyMock.mockResolvedValue("token");
+    vi.mocked(api.get).mockResolvedValue({
+      data: { userType: "company", companyId: 1, registrationCompleted: true },
+    });
+  });
+
+  it("navega para o returnTo salvo quando não há draft pendente", async () => {
+    sessionStorage.setItem("auth0-return-to", "/empresa/leis-de-incentivo");
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AuthRoleRedirect />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.navigateMock).toHaveBeenCalledWith(
+        "/empresa/leis-de-incentivo",
+        { replace: true },
+      );
+    });
+  });
+
+  it("não usa o returnTo quando há draft de company pendente", async () => {
+    sessionStorage.setItem("auth0-return-to", "/empresa/leis-de-incentivo");
+    sessionStorage.setItem("vinculohub:company-signup-draft", JSON.stringify({ payload: null }));
+    mocks.apiPostMock.mockResolvedValue({ data: {} });
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AuthRoleRedirect />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const navigatedToReturnTo = mocks.navigateMock.mock.calls.some(
+        ([path]) => path === "/empresa/leis-de-incentivo",
+      );
+      expect(navigatedToReturnTo).toBe(false);
+    });
   });
 });

--- a/frontend/src/components/auth/AuthRoleRedirect.tsx
+++ b/frontend/src/components/auth/AuthRoleRedirect.tsx
@@ -34,6 +34,7 @@ type AuthenticatedProfile = {
 };
 
 const loginCompletedKey = "auth0-login-completed";
+const returnToKey = "auth0-return-to";
 const npoSignupDraftKey = "vinculohub:npo-signup-draft";
 const companySignupDraftKey = "vinculohub:company-signup-draft";
 const npoWizardProgressKey = "vinculohub:npo-wizard-progress";
@@ -127,7 +128,16 @@ export function AuthRoleRedirect() {
           redirectPath,
         });
 
-        if (redirectPath !== location.pathname) {
+        const returnTo = sessionStorage.getItem(returnToKey)
+        sessionStorage.removeItem(returnToKey)
+
+        const justSubmittedDraft =
+          npoDraftSubmitted || companyDraftSubmitted || hasNpoDraft || hasCompanyDraft
+
+        if (returnTo && !justSubmittedDraft) {
+          logger.info("AuthRedirect", `Restoring deep-link to ${returnTo}`);
+          navigate(returnTo, { replace: true });
+        } else if (redirectPath !== location.pathname) {
           logger.info("AuthRedirect", `Navigating to ${redirectPath}`);
           navigate(redirectPath, { replace: true });
         }

--- a/frontend/src/components/general/IncentiveCard.test.tsx
+++ b/frontend/src/components/general/IncentiveCard.test.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { IncentiveCard } from "./IncentiveCard"
+
+const mocks = vi.hoisted(() => ({ navigateMock: vi.fn() }))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return { ...actual, useNavigate: () => mocks.navigateMock }
+})
+
+describe("IncentiveCard", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renderiza o título 'Leis de Incentivo'", () => {
+    render(<MemoryRouter><IncentiveCard /></MemoryRouter>)
+    expect(screen.getByText("Leis de Incentivo")).toBeInTheDocument()
+  })
+
+  it("renderiza as 6 leis de incentivo", () => {
+    render(<MemoryRouter><IncentiveCard /></MemoryRouter>)
+    expect(screen.getByText("Lei Rouanet (Federal)")).toBeInTheDocument()
+    expect(screen.getByText("Lei do Audiovisual (Federal)")).toBeInTheDocument()
+    expect(screen.getByText("Lei de Incentivo ao Esporte (Federal)")).toBeInTheDocument()
+    expect(screen.getByText("Fundo do Idoso (Federal/Estadual/Municipal)")).toBeInTheDocument()
+    expect(screen.getByText("Fundo de Criança e Adolescente (Federal/Estadual/Municipal)")).toBeInTheDocument()
+    expect(screen.getByText("PRONON/PRONAS (Federal)")).toBeInTheDocument()
+  })
+
+  it("clicar em 'Ver projetos disponíveis' navega para /empresa/leis-de-incentivo", async () => {
+    render(<MemoryRouter><IncentiveCard /></MemoryRouter>)
+    await userEvent.click(screen.getByRole("button", { name: "Ver projetos disponíveis" }))
+    expect(mocks.navigateMock).toHaveBeenCalledWith("/empresa/leis-de-incentivo")
+  })
+})

--- a/frontend/src/components/general/IncentiveCard.tsx
+++ b/frontend/src/components/general/IncentiveCard.tsx
@@ -1,54 +1,52 @@
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined"
-
+import { useNavigate } from "react-router-dom"
 
 export function IncentiveCard() {
-return(
-        <section> 
-          <div className="bg-white rounded-[10px] shadow-md p-8 ">
-            <div className="flex items-start gap-4 mb-6">
-              <div className="w-14 h-14 rounded-full bg-vinculo-dark text-white grid place-items-center">
-                <DescriptionOutlinedIcon className="text-white" style={{ fontSize: 37  }} />
-              </div>
-              <div>
-                <h3 className="text-2xl font-semibold text-vinculo-dark">
-                  Leis de Incentivo
-                </h3>
-                <p className="text-slate-600 mt-2 max-w-xl">
-                  Apoie projetos através de leis de incentivo fiscal e obtenha benefícios tributários.
-                </p>
-              </div>
-            </div>
+  const navigate = useNavigate()
 
-            <div className="space-y-3">
-              <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
-                Lei Rouanet (Federal)
-              </div>
-              <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
-                Lei do Audiovisual (Federal)
-              </div>
-              <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
-                Lei de Incentivo ao Esporte (Federal)
-              </div>
-              <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
-                Fundo do Idoso (Federal/Estadual/Municipal)
-              </div>
-              <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
-                Fundo de Criança e Adolescente (Federal/Estadual/Municipal)
-              </div>
-              <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
-                PRONON/PRONAS (Federal)
-              </div>
-            </div>
-
-            <button className="mt-8 w-full rounded-2xl bg-vinculo-dark px-6 py-4 text-white text-lg  hover:bg-slate-800 transition-colors">
-              Ver projetos disponíveis
-            </button>
+  return (
+    <section>
+      <div className="bg-white rounded-[10px] shadow-md p-8">
+        <div className="flex items-start gap-4 mb-6">
+          <div className="w-14 h-14 rounded-full bg-vinculo-dark text-white grid place-items-center">
+            <DescriptionOutlinedIcon className="text-white" style={{ fontSize: 37 }} />
           </div>
+          <div>
+            <h3 className="text-2xl font-semibold text-vinculo-dark">Leis de Incentivo</h3>
+            <p className="text-slate-600 mt-2 max-w-xl">
+              Apoie projetos através de leis de incentivo fiscal e obtenha benefícios tributários.
+            </p>
+          </div>
+        </div>
 
-</section>
+        <div className="space-y-3">
+          <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
+            Lei Rouanet (Federal)
+          </div>
+          <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
+            Lei do Audiovisual (Federal)
+          </div>
+          <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
+            Lei de Incentivo ao Esporte (Federal)
+          </div>
+          <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
+            Fundo do Idoso (Federal/Estadual/Municipal)
+          </div>
+          <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
+            Fundo de Criança e Adolescente (Federal/Estadual/Municipal)
+          </div>
+          <div className="rounded-2xl font-semibold bg-slate-100 px-5 py-4 text-slate-700">
+            PRONON/PRONAS (Federal)
+          </div>
+        </div>
 
-
-)
-
-
+        <button
+          onClick={() => navigate("/empresa/leis-de-incentivo")}
+          className="mt-8 w-full rounded-2xl bg-vinculo-dark px-6 py-4 text-white text-lg hover:bg-slate-800 transition-colors"
+        >
+          Ver projetos disponíveis
+        </button>
+      </div>
+    </section>
+  )
 }

--- a/frontend/src/components/general/InvestmentCard.test.tsx
+++ b/frontend/src/components/general/InvestmentCard.test.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { InvestmentCard } from "./InvestmentCard"
+
+const mocks = vi.hoisted(() => ({ navigateMock: vi.fn() }))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return { ...actual, useNavigate: () => mocks.navigateMock }
+})
+
+describe("InvestmentCard", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("renderiza o título 'Investimento Social Privado'", () => {
+    render(<MemoryRouter><InvestmentCard /></MemoryRouter>)
+    expect(screen.getByText("Investimento Social Privado")).toBeInTheDocument()
+  })
+
+  it("renderiza os 3 projetos de exemplo", () => {
+    render(<MemoryRouter><InvestmentCard /></MemoryRouter>)
+    expect(screen.getByText("Educação Ambiental nas Escolas")).toBeInTheDocument()
+    expect(screen.getByText("Saúde Comunitária")).toBeInTheDocument()
+    expect(screen.getByText("Inclusão Digital")).toBeInTheDocument()
+  })
+
+  it("clicar em 'Explorar oportunidades' navega para /empresa/investimento-social-privado", async () => {
+    render(<MemoryRouter><InvestmentCard /></MemoryRouter>)
+    await userEvent.click(screen.getByRole("button", { name: "Explorar oportunidades" }))
+    expect(mocks.navigateMock).toHaveBeenCalledWith("/empresa/investimento-social-privado")
+  })
+})

--- a/frontend/src/components/general/InvestmentCard.tsx
+++ b/frontend/src/components/general/InvestmentCard.tsx
@@ -1,53 +1,54 @@
-
 import AttachMoneyOutlinedIcon from "@mui/icons-material/AttachMoneyOutlined"
 import CheckOutlinedIcon from "@mui/icons-material/CheckOutlined"
+import { useNavigate } from "react-router-dom"
 
 export function InvestmentCard() {
-return (
- <div className="bg-white rounded-[10px] border border-slate-200 shadow-sm p-8">
-            <div className="flex items-start gap-4 mb-6">
-              <div className="w-14 h-14 rounded-full bg-vinculo-green text-white grid place-items-center">
-                <AttachMoneyOutlinedIcon className="text-white " style={{ fontSize: 37 }} />
-              </div>
-              <div>
-                <h3 className="text-2xl font-semibold text-vinculo-dark">
-                  Investimento Social Privado
-                </h3>
-                <p className="text-slate-600 mt-2 max-w-xl">
-                  Invista diretamente em projetos sociais alinhados com os valores da sua empresa.
-                </p>
-              </div>
-            </div>
+  const navigate = useNavigate()
 
+  return (
+    <div className="bg-white rounded-[10px] border border-slate-200 shadow-sm p-8">
+      <div className="flex items-start gap-4 mb-6">
+        <div className="w-14 h-14 rounded-full bg-vinculo-green text-white grid place-items-center">
+          <AttachMoneyOutlinedIcon className="text-white" style={{ fontSize: 37 }} />
+        </div>
+        <div>
+          <h3 className="text-2xl font-semibold text-vinculo-dark">Investimento Social Privado</h3>
+          <p className="text-slate-600 mt-2 max-w-xl">
+            Invista diretamente em projetos sociais alinhados com os valores da sua empresa.
+          </p>
+        </div>
+      </div>
 
-            <div className="space-y-4">
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex items-start gap-3">
-                  <CheckOutlinedIcon className="text-vinculo-green mt-1" style={{ fontSize: 20 }} />
-                  <span className="text-slate-700 text-lg">Educação Ambiental nas Escolas</span>
-                </div>
-                <span className="text-slate-500">R$ 50.000 - R$ 180.000</span>
-              </div>
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex items-start gap-3">
-                  <CheckOutlinedIcon className="text-vinculo-green mt-1" style={{ fontSize: 20 }} />
-                  <span className="text-slate-700 text-lg">Saúde Comunitária</span>
-                </div>
-                <span className="text-slate-500">R$ 75.000 - R$ 85.000</span>
-              </div>
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex items-start gap-3">
-                  <CheckOutlinedIcon className="text-vinculo-green mt-1" style={{ fontSize: 20 }} />
-                  <span className="text-slate-700 text-lg">Inclusão Digital</span>
-                </div>
-                <span className="text-slate-500">R$ 20.000 - R$ 80.000</span>
-              </div>
-            </div>
-
-            <button className="mt-8 w-full rounded-2xl bg-vinculo-green px-6 py-4 text-white text-lg hover:bg-emerald-600 transition-colors">
-              Explorar oportunidades
-            </button>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <CheckOutlinedIcon className="text-vinculo-green mt-1" style={{ fontSize: 20 }} />
+            <span className="text-slate-700 text-lg">Educação Ambiental nas Escolas</span>
           </div>
-)
+          <span className="text-slate-500 shrink-0">R$ 50.000 - R$ 180.000</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <CheckOutlinedIcon className="text-vinculo-green mt-1" style={{ fontSize: 20 }} />
+            <span className="text-slate-700 text-lg">Saúde Comunitária</span>
+          </div>
+          <span className="text-slate-500 shrink-0">R$ 75.000 - R$ 85.000</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <CheckOutlinedIcon className="text-vinculo-green mt-1" style={{ fontSize: 20 }} />
+            <span className="text-slate-700 text-lg">Inclusão Digital</span>
+          </div>
+          <span className="text-slate-500 shrink-0">R$ 20.000 - R$ 80.000</span>
+        </div>
+      </div>
 
+      <button
+        onClick={() => navigate("/empresa/investimento-social-privado")}
+        className="mt-8 w-full rounded-2xl bg-vinculo-green px-6 py-4 text-white text-lg hover:bg-emerald-600 transition-colors"
+      >
+        Explorar oportunidades
+      </button>
+    </div>
+  )
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -29,6 +29,9 @@ createRoot(document.getElementById("root")!).render(
       }}
       onRedirectCallback={(appState) => {
         sessionStorage.setItem("auth0-login-completed", "true")
+        if (appState?.returnTo && appState.returnTo !== "/") {
+          sessionStorage.setItem("auth0-return-to", appState.returnTo)
+        }
         window.history.replaceState(
           {},
           document.title,

--- a/frontend/src/pages/CompanyDashboard/EsgImpactSection.test.tsx
+++ b/frontend/src/pages/CompanyDashboard/EsgImpactSection.test.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import type { SvgIconComponent } from "@mui/icons-material"
+import { EsgImpactSection } from "./EsgImpactSection"
+import type { EsgPillar } from "./mockData"
+
+const mockIcon = (() => <svg data-testid="mock-icon" />) as unknown as SvgIconComponent
+
+const mockPillars: EsgPillar[] = [
+  { label: "Ambiental", projects: 3, percentageOfTotal: 45, Icon: mockIcon, iconBgClass: "bg-blue-50", iconColorClass: "text-blue-500", barColorClass: "bg-blue-500" },
+  { label: "Social", projects: 4, percentageOfTotal: 35, Icon: mockIcon, iconBgClass: "bg-green-50", iconColorClass: "text-green-500", barColorClass: "bg-green-500" },
+  { label: "Governança", projects: 2, percentageOfTotal: 20, Icon: mockIcon, iconBgClass: "bg-amber-50", iconColorClass: "text-amber-500", barColorClass: "bg-amber-500" },
+]
+
+const mockFooter = { beneficiaries: "1.250", communities: 8, sdgs: 5, states: 3 }
+
+describe("EsgImpactSection", () => {
+  it("renderiza o título 'Impacto ESG'", () => {
+    render(<EsgImpactSection pillars={mockPillars} footerStats={mockFooter} />)
+    expect(screen.getByText("Impacto ESG")).toBeInTheDocument()
+  })
+
+  it("renderiza os 3 pilares com seus labels", () => {
+    render(<EsgImpactSection pillars={mockPillars} footerStats={mockFooter} />)
+    expect(screen.getByText("Ambiental")).toBeInTheDocument()
+    expect(screen.getByText("Social")).toBeInTheDocument()
+    expect(screen.getByText("Governança")).toBeInTheDocument()
+  })
+
+  it("exibe contagens de projetos de cada pilar", () => {
+    render(<EsgImpactSection pillars={mockPillars} footerStats={mockFooter} />)
+    expect(screen.getByText("3 projetos apoiados")).toBeInTheDocument()
+    expect(screen.getByText("4 projetos apoiados")).toBeInTheDocument()
+    expect(screen.getByText("2 projetos apoiados")).toBeInTheDocument()
+  })
+
+  it("renderiza os 4 stats do rodapé", () => {
+    render(<EsgImpactSection pillars={mockPillars} footerStats={mockFooter} />)
+    expect(screen.getByText("1.250")).toBeInTheDocument()
+    expect(screen.getByText("Pessoas beneficiadas")).toBeInTheDocument()
+    expect(screen.getByText("8")).toBeInTheDocument()
+    expect(screen.getByText("5")).toBeInTheDocument()
+    expect(screen.getByText("3")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyDashboard/EsgImpactSection.tsx
+++ b/frontend/src/pages/CompanyDashboard/EsgImpactSection.tsx
@@ -1,0 +1,62 @@
+import { ProgressBar } from "./ProgressBar"
+import type { EsgFooterStats, EsgPillar } from "./mockData"
+
+interface EsgImpactSectionProps {
+  pillars: EsgPillar[]
+  footerStats: EsgFooterStats
+}
+
+export function EsgImpactSection({ pillars, footerStats }: EsgImpactSectionProps) {
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 sm:p-8 flex flex-col gap-6">
+      <h2 className="text-2xl font-medium leading-9 text-vinculo-dark">Impacto ESG</h2>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {pillars.map((pillar) => (
+          <div key={pillar.label} className="flex flex-col items-center gap-3 text-center">
+            <div
+              className={`w-12 h-12 rounded-full flex items-center justify-center ${pillar.iconBgClass}`}
+            >
+              <pillar.Icon className={pillar.iconColorClass} />
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="font-medium text-slate-800">{pillar.label}</span>
+              <span className="text-sm text-slate-500">{pillar.projects} projetos apoiados</span>
+            </div>
+            <div className="w-full flex flex-col gap-1">
+              <ProgressBar value={pillar.percentageOfTotal} colorClass={pillar.barColorClass} />
+              <span className="text-xs text-slate-500">
+                {pillar.percentageOfTotal}% do investimento total
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <hr className="border-slate-200" />
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+        <div className="flex flex-col gap-1">
+          <span className="text-3xl font-semibold text-vinculo-dark">
+            {footerStats.beneficiaries}
+          </span>
+          <span className="text-sm text-slate-500">Pessoas beneficiadas</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-3xl font-semibold text-vinculo-dark">
+            {footerStats.communities}
+          </span>
+          <span className="text-sm text-slate-500">Comunidades impactadas</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-3xl font-semibold text-vinculo-dark">{footerStats.sdgs}</span>
+          <span className="text-sm text-slate-500">ODS atendidos</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-3xl font-semibold text-vinculo-dark">{footerStats.states}</span>
+          <span className="text-sm text-slate-500">Estados alcançados</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyDashboard/InvestmentBudgetCard.test.tsx
+++ b/frontend/src/pages/CompanyDashboard/InvestmentBudgetCard.test.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { InvestmentBudgetCard } from "./InvestmentBudgetCard"
+
+const mockData = {
+  totalDisplay: "R$ 250.000",
+  usedDisplay: "R$ 150.000",
+  usedPercentage: 60,
+}
+
+describe("InvestmentBudgetCard", () => {
+  it("exibe o valor total disponível", () => {
+    render(<InvestmentBudgetCard data={mockData} />)
+    expect(screen.getAllByText("R$ 250.000")).toHaveLength(2)
+  })
+
+  it("exibe o valor utilizado", () => {
+    render(<InvestmentBudgetCard data={mockData} />)
+    expect(screen.getByText("R$ 150.000")).toBeInTheDocument()
+  })
+
+  it("exibe o percentual utilizado no rodapé", () => {
+    render(<InvestmentBudgetCard data={mockData} />)
+    expect(screen.getByText("60% utilizado")).toBeInTheDocument()
+  })
+
+  it("exibe os labels 'Total disponível' e 'Utilizado'", () => {
+    render(<InvestmentBudgetCard data={mockData} />)
+    expect(screen.getByText("Total disponível")).toBeInTheDocument()
+    expect(screen.getByText("Utilizado")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyDashboard/InvestmentBudgetCard.tsx
+++ b/frontend/src/pages/CompanyDashboard/InvestmentBudgetCard.tsx
@@ -1,0 +1,44 @@
+import TrendingUpIcon from "@mui/icons-material/TrendingUp"
+import { ProgressBar } from "./ProgressBar"
+import type { InvestmentBudget } from "./mockData"
+
+interface InvestmentBudgetCardProps {
+  data: InvestmentBudget
+}
+
+export function InvestmentBudgetCard({ data }: InvestmentBudgetCardProps) {
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 sm:p-8 flex flex-col gap-4">
+      <p className="text-sm text-slate-500">Investimento Disponível</p>
+
+      <div className="flex items-center gap-2">
+        <span className="text-3xl sm:text-4xl font-semibold text-vinculo-green">
+          {data.totalDisplay}
+        </span>
+        <TrendingUpIcon className="text-vinculo-green" fontSize="small" />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-slate-600">Total disponível</span>
+          <span className="text-slate-700 font-medium">
+            {data.totalDisplay}
+          </span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-slate-600">Utilizado</span>
+          <span className="text-vinculo-green font-medium">
+            {data.usedDisplay}
+          </span>
+        </div>
+      </div>
+
+      <ProgressBar value={data.usedPercentage} colorClass="bg-vinculo-green" />
+
+      <div className="flex justify-between text-xs text-slate-500">
+        <span>{data.usedPercentage}% utilizado</span>
+        <span>100%</span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyDashboard/InvestmentModalitiesSection.test.tsx
+++ b/frontend/src/pages/CompanyDashboard/InvestmentModalitiesSection.test.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { InvestmentModalitiesSection } from "./InvestmentModalitiesSection"
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+describe("InvestmentModalitiesSection", () => {
+  it("renderiza o título da seção", () => {
+    render(
+      <MemoryRouter>
+        <InvestmentModalitiesSection />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText("Modalidades de Investimento")).toBeInTheDocument()
+  })
+
+  it("renderiza o card de Leis de Incentivo", () => {
+    render(
+      <MemoryRouter>
+        <InvestmentModalitiesSection />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText("Leis de Incentivo")).toBeInTheDocument()
+  })
+
+  it("renderiza o card de Investimento Social Privado", () => {
+    render(
+      <MemoryRouter>
+        <InvestmentModalitiesSection />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText("Investimento Social Privado")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyDashboard/InvestmentModalitiesSection.tsx
+++ b/frontend/src/pages/CompanyDashboard/InvestmentModalitiesSection.tsx
@@ -1,0 +1,16 @@
+import { IncentiveCard } from "../../components/general/IncentiveCard"
+import { InvestmentCard } from "../../components/general/InvestmentCard"
+
+export function InvestmentModalitiesSection() {
+  return (
+    <section className="flex flex-col gap-6">
+      <h2 className="text-2xl font-medium leading-9 text-vinculo-dark">
+        Modalidades de Investimento
+      </h2>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <IncentiveCard />
+        <InvestmentCard />
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/CompanyDashboard/ProgressBar.test.tsx
+++ b/frontend/src/pages/CompanyDashboard/ProgressBar.test.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render } from "@testing-library/react"
+import { ProgressBar } from "./ProgressBar"
+
+function getBar(container: HTMLElement) {
+  return container.querySelector("[style]") as HTMLElement
+}
+
+describe("ProgressBar", () => {
+  it("define width de acordo com value", () => {
+    const { container } = render(<ProgressBar value={60} />)
+    expect(getBar(container).style.width).toBe("60%")
+  })
+
+  it("clamp: valor negativo vira 0%", () => {
+    const { container } = render(<ProgressBar value={-20} />)
+    expect(getBar(container).style.width).toBe("0%")
+  })
+
+  it("clamp: valor acima de 100 vira 100%", () => {
+    const { container } = render(<ProgressBar value={150} />)
+    expect(getBar(container).style.width).toBe("100%")
+  })
+
+  it("aplica colorClass na barra interna", () => {
+    const { container } = render(<ProgressBar value={50} colorClass="bg-red-500" />)
+    expect(getBar(container).className).toContain("bg-red-500")
+  })
+
+  it("aplica trackClass no container externo", () => {
+    const { container } = render(<ProgressBar value={50} trackClass="bg-gray-100" />)
+    expect(container.firstChild as HTMLElement).toHaveClass("bg-gray-100")
+  })
+})

--- a/frontend/src/pages/CompanyDashboard/ProgressBar.tsx
+++ b/frontend/src/pages/CompanyDashboard/ProgressBar.tsx
@@ -1,0 +1,22 @@
+interface ProgressBarProps {
+  value: number
+  colorClass?: string
+  trackClass?: string
+}
+
+export function ProgressBar({
+  value,
+  colorClass = "bg-vinculo-green",
+  trackClass = "bg-slate-200",
+}: ProgressBarProps) {
+  const clamped = Math.max(0, Math.min(100, value))
+
+  return (
+    <div className={`w-full h-2 rounded-full overflow-hidden ${trackClass}`}>
+      <div
+        className={`h-full rounded-full transition-all duration-300 ${colorClass}`}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyDashboard/SupportedProjectsCard.test.tsx
+++ b/frontend/src/pages/CompanyDashboard/SupportedProjectsCard.test.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { SupportedProjectsCard } from "./SupportedProjectsCard"
+
+const mockData = { active: 5, incentiveLaws: 3, privateInvestment: 2 }
+
+describe("SupportedProjectsCard", () => {
+  it("exibe os 3 valores de stats", () => {
+    render(<SupportedProjectsCard data={mockData} />)
+    expect(screen.getByText("5")).toBeInTheDocument()
+    expect(screen.getByText("3")).toBeInTheDocument()
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("exibe os labels dos stats", () => {
+    render(<SupportedProjectsCard data={mockData} />)
+    expect(screen.getByText("Projetos ativos")).toBeInTheDocument()
+    expect(screen.getByText("Leis de incentivo")).toBeInTheDocument()
+    expect(screen.getByText("Investimento privado")).toBeInTheDocument()
+  })
+
+  it("exibe o botão 'Ver todos os projetos'", () => {
+    render(<SupportedProjectsCard data={mockData} />)
+    expect(screen.getByText("Ver todos os projetos")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyDashboard/SupportedProjectsCard.tsx
+++ b/frontend/src/pages/CompanyDashboard/SupportedProjectsCard.tsx
@@ -1,0 +1,42 @@
+import DescriptionIcon from "@mui/icons-material/Description"
+import type { SupportedProjectsStats } from "./mockData"
+
+interface SupportedProjectsCardProps {
+  data: SupportedProjectsStats
+}
+
+export function SupportedProjectsCard({ data }: SupportedProjectsCardProps) {
+  return (
+    <div className="bg-vinculo-green rounded-2xl p-6 sm:p-8 flex flex-col justify-between gap-4">
+      <div className="flex justify-between items-start">
+        <p className="text-sm text-white/90">Projetos Apoiados</p>
+        <DescriptionIcon className="text-white/80" fontSize="small" />
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-3xl sm:text-4xl font-semibold text-white">
+            {data.active}
+          </span>
+          <span className="text-xs text-white/80 leading-tight">Projetos ativos</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-3xl sm:text-4xl font-semibold text-white">
+            {data.incentiveLaws}
+          </span>
+          <span className="text-xs text-white/80 leading-tight">Leis de incentivo</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-3xl sm:text-4xl font-semibold text-white">
+            {data.privateInvestment}
+          </span>
+          <span className="text-xs text-white/80 leading-tight">Investimento privado</span>
+        </div>
+      </div>
+
+      <button className="bg-white text-vinculo-green font-semibold rounded-lg px-4 py-3 w-full text-sm">
+        Ver todos os projetos
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyDashboard/index.test.tsx
+++ b/frontend/src/pages/CompanyDashboard/index.test.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { CompanyDashboard } from "./index"
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+vi.mock("../../components/general/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}))
+
+describe("CompanyDashboard", () => {
+  it("renderiza o título 'Dashboard Empresarial'", () => {
+    render(<MemoryRouter><CompanyDashboard /></MemoryRouter>)
+    expect(screen.getByText("Dashboard Empresarial")).toBeInTheDocument()
+  })
+
+  it("renderiza a saudação com o nome mockado", () => {
+    render(<MemoryRouter><CompanyDashboard /></MemoryRouter>)
+    expect(screen.getByText(/Bem-vindo de volta, Empresa ABC/)).toBeInTheDocument()
+  })
+
+  it("renderiza a seção de investimento disponível", () => {
+    render(<MemoryRouter><CompanyDashboard /></MemoryRouter>)
+    expect(screen.getByText("Investimento Disponível")).toBeInTheDocument()
+  })
+
+  it("renderiza a seção de projetos apoiados", () => {
+    render(<MemoryRouter><CompanyDashboard /></MemoryRouter>)
+    expect(screen.getByText("Projetos Apoiados")).toBeInTheDocument()
+  })
+
+  it("renderiza a seção de modalidades de investimento", () => {
+    render(<MemoryRouter><CompanyDashboard /></MemoryRouter>)
+    expect(screen.getByText("Modalidades de Investimento")).toBeInTheDocument()
+  })
+
+  it("renderiza a seção de impacto ESG", () => {
+    render(<MemoryRouter><CompanyDashboard /></MemoryRouter>)
+    expect(screen.getByText("Impacto ESG")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyDashboard/index.tsx
+++ b/frontend/src/pages/CompanyDashboard/index.tsx
@@ -1,0 +1,39 @@
+import { Header } from "../../components/general/Header"
+import { EsgImpactSection } from "./EsgImpactSection"
+import { InvestmentBudgetCard } from "./InvestmentBudgetCard"
+import { InvestmentModalitiesSection } from "./InvestmentModalitiesSection"
+import { SupportedProjectsCard } from "./SupportedProjectsCard"
+import {
+  mockBudget,
+  mockCompanyName,
+  mockEsgFooterStats,
+  mockEsgPillars,
+  mockSupportedProjects,
+} from "./mockData"
+
+export const CompanyDashboard = () => {
+  return (
+    <div className="min-h-screen bg-slate-50 flex flex-col gap-10 pb-20">
+      <Header />
+      <main className="max-w-7xl mx-auto w-full px-4 sm:px-6 flex flex-col gap-8">
+        <header>
+          <h1 className="text-2xl font-medium leading-9 text-vinculo-dark">
+            Dashboard Empresarial
+          </h1>
+          <p className="text-base font-normal leading-6 text-slate-600">
+            Bem-vindo de volta, {mockCompanyName}
+          </p>
+        </header>
+
+        <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <InvestmentBudgetCard data={mockBudget} />
+          <SupportedProjectsCard data={mockSupportedProjects} />
+        </section>
+
+        <InvestmentModalitiesSection />
+
+        <EsgImpactSection pillars={mockEsgPillars} footerStats={mockEsgFooterStats} />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyDashboard/mockData.ts
+++ b/frontend/src/pages/CompanyDashboard/mockData.ts
@@ -1,0 +1,112 @@
+import type { SvgIconComponent } from "@mui/icons-material"
+import PublicIcon from "@mui/icons-material/Public"
+import PeopleIcon from "@mui/icons-material/People"
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents"
+
+export interface InvestmentBudget {
+  totalDisplay: string
+  usedDisplay: string
+  usedPercentage: number
+}
+
+export interface SupportedProjectsStats {
+  active: number
+  incentiveLaws: number
+  privateInvestment: number
+}
+
+export interface EsgPillar {
+  label: string
+  projects: number
+  percentageOfTotal: number
+  Icon: SvgIconComponent
+  iconBgClass: string
+  iconColorClass: string
+  barColorClass: string
+}
+
+export interface EsgFooterStats {
+  beneficiaries: string
+  communities: number
+  sdgs: number
+  states: number
+}
+
+// TODO(backend): substituir pelo nome da empresa logada.
+//   Endpoint a criar: estender GET /api/me/profile (MeController) para incluir
+//   companyName/legalName/socialName, OU novo GET /api/me/company retornando CompanyDTO.
+//   Hoje /api/me/profile só retorna companyId (Integer), sem o nome.
+export const mockCompanyName = "Empresa ABC"
+
+// TODO(backend): substituir pelo saldo de investimento da empresa.
+//   Endpoint a criar: GET /api/me/company/budget retornando
+//   { totalDisplay: string, usedDisplay: string, usedPercentage: number }
+//   (valores monetários formatados pt-BR; backend é responsável pela formatação).
+//   Não existe modelo de orçamento por empresa hoje — requer campo novo na entidade
+//   Company ou nova entidade CompanyBudget.
+export const mockBudget: InvestmentBudget = {
+  totalDisplay: "R$ 250.000",
+  usedDisplay: "R$ 150.000",
+  usedPercentage: 60,
+}
+
+// TODO(backend): substituir pela contagem de projetos apoiados pela empresa.
+//   Endpoint a criar: GET /api/me/company/supported-projects/stats retornando
+//   { active: number, incentiveLaws: number, privateInvestment: number }.
+//   Requer relacionamento Empresa↔Projeto no modelo (não existe; ProjectController
+//   hoje só filtra por npoId/status/title/odsCodes/type, sem companyId).
+export const mockSupportedProjects: SupportedProjectsStats = {
+  active: 5,
+  incentiveLaws: 3,
+  privateInvestment: 2,
+}
+
+// TODO(backend): substituir pelas métricas de pilares ESG da empresa.
+//   Endpoint a criar: GET /api/me/company/esg-pillars retornando array de
+//   { label, projects, percentageOfTotal } para Ambiental/Social/Governança.
+//   Flags ESG hoje vivem em Npo (environmental/social/governance), não em Project —
+//   depende do relacionamento Empresa↔Projeto e de propagar pilares para Project
+//   ou agregar via Npo. Os campos visuais (Icon/iconBgClass/iconColorClass/
+//   barColorClass) permanecem definidos no frontend mesmo após a integração.
+export const mockEsgPillars: EsgPillar[] = [
+  {
+    label: "Ambiental",
+    projects: 3,
+    percentageOfTotal: 45,
+    Icon: PublicIcon,
+    iconBgClass: "bg-blue-50",
+    iconColorClass: "text-blue-500",
+    barColorClass: "bg-vinculo-dark",
+  },
+  {
+    label: "Social",
+    projects: 4,
+    percentageOfTotal: 35,
+    Icon: PeopleIcon,
+    iconBgClass: "bg-green-50",
+    iconColorClass: "text-vinculo-green",
+    barColorClass: "bg-vinculo-green",
+  },
+  {
+    label: "Governança",
+    projects: 2,
+    percentageOfTotal: 20,
+    Icon: EmojiEventsIcon,
+    iconBgClass: "bg-amber-50",
+    iconColorClass: "text-amber-500",
+    barColorClass: "bg-red-700",
+  },
+]
+
+// TODO(backend): substituir pelos stats de impacto agregado da empresa.
+//   Endpoint a criar: GET /api/me/company/impact-stats retornando
+//   { beneficiaries: string, communities: number, sdgs: number, states: number }
+//   (beneficiaries formatado pt-BR pelo backend, ex.: "1.250").
+//   Requer modelar campos de impacto em Project (beneficiariesCount/communities/
+//   states) ou nova entidade ProjectImpact. Hoje só Project.odsCodes existe.
+export const mockEsgFooterStats: EsgFooterStats = {
+  beneficiaries: "1.250",
+  communities: 8,
+  sdgs: 5,
+  states: 3,
+}

--- a/frontend/src/pages/RegisterPage/index.test.tsx
+++ b/frontend/src/pages/RegisterPage/index.test.tsx
@@ -244,6 +244,6 @@ describe("RegisterPage", () => {
       '"tipoProjeto":"governamental"',
     );
 
-    resolveLogin?.();
+    (resolveLogin as (() => void) | null)?.();
   });
 });

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -7,6 +7,7 @@ import { AuthRoleRedirect } from "../components/auth/AuthRoleRedirect"
 import { ProtectedRoute } from "../components/auth/ProtectedRoute"
 import { RoleHomePage } from "../pages/RoleHomePage"
 import { CompanyRegistrationPage } from "../pages/CompanyRegistration/registration"
+import { CompanyDashboard } from "../pages/CompanyDashboard"
 
 export const AppRouter = () => (
   <BrowserRouter>
@@ -43,10 +44,7 @@ export const AppRouter = () => (
         path="/empresa/dashboard"
         element={
           <ProtectedRoute requiredRole="COMPANY">
-            <RoleHomePage
-              title="Painel da empresa"
-              description="Encontre projetos, acompanhe parcerias e gerencie seu perfil institucional."
-            />
+            <CompanyDashboard />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/test/jest-dom.d.ts
+++ b/frontend/src/test/jest-dom.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@testing-library/jest-dom" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"],
+  "exclude": []
+}


### PR DESCRIPTION
## Issue Link
Closes #149 

## Description
Adiciona Dashboard Empresarial (rota /empresa/dashboard) substituindo a RoleHomePage genérica. Inclui seções de orçamento, projetos apoiados, modalidades de investimento (com cards IncentiveCard e InvestmentCard que navegam para /empresa/leis-de-incentivo e /empresa/investimento-social-privado), impacto ESG e progresso. Inclui infraestrutura de testes (tsconfig.test.json + jest-dom).

Inclui também o fix de deep-link returnTo em AuthRoleRedirect/main.tsx, aplicado como melhoria de auth genérica.

Pequenos fixes de TS:
- Tipa o mockIcon e mockPillars no teste de EsgImpactSection.
- Cast explícito em resolveLogin?.() em RegisterPage/index.test.tsx.

## Task Notes
## Screenshots
<img width="2954" height="3434" alt="localhost_5173_empresa_dashboard (1)" src="https://github.com/user-attachments/assets/ac46ff34-c666-43c4-b714-ff81895741f0" />
