### PR TITLE
(US-06) Page Investimento social privado

### DIFF
--- a/frontend/src/api/projects.test.ts
+++ b/frontend/src/api/projects.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { fetchProjects } from "./projects"
+
+const mocks = vi.hoisted(() => ({
+  apiGetMock: vi.fn(),
+}))
+
+vi.mock("../services/api", () => ({
+  api: { get: mocks.apiGetMock },
+}))
+
+vi.mock("../utils/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}))
+
+const mockPage = {
+  content: [{ id: 1, title: "Projeto A", status: "ACTIVE", npoId: 10, npoName: "ONG A", npoPhone: "51999", startDate: "2026-01-01" }],
+  totalElements: 1,
+  totalPages: 1,
+  number: 0,
+  size: 50,
+  first: true,
+  last: true,
+}
+
+describe("fetchProjects", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.apiGetMock.mockResolvedValue({ data: mockPage })
+  })
+
+  it("chama GET /api/projects com os params corretos", async () => {
+    await fetchProjects({ type: "TAX_INCENTIVE_LAW", size: 50 })
+    expect(mocks.apiGetMock).toHaveBeenCalledWith("/api/projects", {
+      params: { type: "TAX_INCENTIVE_LAW", size: 50 },
+      headers: undefined,
+    })
+  })
+
+  it("inclui header Authorization quando token é passado", async () => {
+    await fetchProjects({}, "meu-token")
+    expect(mocks.apiGetMock).toHaveBeenCalledWith("/api/projects", {
+      params: {},
+      headers: { Authorization: "Bearer meu-token" },
+    })
+  })
+
+  it("omite header Authorization quando token não é passado", async () => {
+    await fetchProjects({ type: "SOCIAL_INVESTMENT_LAW" })
+    expect(mocks.apiGetMock).toHaveBeenCalledWith("/api/projects", {
+      params: { type: "SOCIAL_INVESTMENT_LAW" },
+      headers: undefined,
+    })
+  })
+
+  it("retorna os dados do response corretamente", async () => {
+    const result = await fetchProjects()
+    expect(result).toEqual(mockPage)
+    expect(result.content).toHaveLength(1)
+    expect(result.totalElements).toBe(1)
+  })
+
+  it("propaga o erro quando api.get rejeita", async () => {
+    mocks.apiGetMock.mockRejectedValue(new Error("Network error"))
+    await expect(fetchProjects()).rejects.toThrow("Network error")
+  })
+})

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -1,0 +1,55 @@
+import { api } from "../services/api"
+import { logger } from "../utils/logger"
+
+export type ProjectStatus = "ACTIVE" | "COMPLETED" | "CANCELLED"
+export type ProjectType = "SOCIAL_INVESTMENT_LAW" | "TAX_INCENTIVE_LAW"
+
+export interface ProjectListItem {
+  id: number
+  title: string
+  status: ProjectStatus
+  npoId: number
+  npoName: string
+  npoPhone: string
+  startDate: string
+}
+
+export interface PageResponse<T> {
+  content: T[]
+  totalElements: number
+  totalPages: number
+  number: number
+  size: number
+  first: boolean
+  last: boolean
+}
+
+export interface ProjectFilterParams {
+  type?: ProjectType
+  status?: ProjectStatus
+  title?: string
+  npoId?: number
+  page?: number
+  size?: number
+}
+
+export async function fetchProjects(
+  params: ProjectFilterParams = {},
+  token?: string,
+): Promise<PageResponse<ProjectListItem>> {
+  logger.info("ProjectsAPI", "Fetching projects", params)
+  try {
+    const { data } = await api.get<PageResponse<ProjectListItem>>("/api/projects", {
+      params,
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    })
+    logger.info("ProjectsAPI", "Projects fetched", {
+      count: data.totalElements,
+      pageSize: data.size,
+    })
+    return data
+  } catch (error) {
+    logger.error("ProjectsAPI", "Failed to fetch projects", error)
+    throw error
+  }
+}

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/HowItWorksSection.test.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/HowItWorksSection.test.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { HowItWorksSection } from "./HowItWorksSection"
+
+describe("HowItWorksSection", () => {
+  it("renderiza o título da seção", () => {
+    render(<HowItWorksSection />)
+    expect(screen.getByText("Como funciona o Investimento Social Privado?")).toBeInTheDocument()
+  })
+
+  it("renderiza os 4 passos numerados", () => {
+    render(<HowItWorksSection />)
+    expect(screen.getByText("1. Escolha projetos alinhados")).toBeInTheDocument()
+    expect(screen.getByText("2. Demonstre interesse")).toBeInTheDocument()
+    expect(screen.getByText("3. Invista diretamente")).toBeInTheDocument()
+    expect(screen.getByText("4. Acompanhe o impacto")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/HowItWorksSection.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/HowItWorksSection.tsx
@@ -1,0 +1,40 @@
+const STEPS = [
+  {
+    title: "1. Escolha projetos alinhados",
+    description:
+      "Selecione projetos que estejam alinhados com os valores e objetivos estratégicos da sua empresa através dos temas de interesse.",
+  },
+  {
+    title: "2. Demonstre interesse",
+    description:
+      "Entre em contato direto com as organizações e inicie o diálogo para entender melhor o projeto e as necessidades.",
+  },
+  {
+    title: "3. Invista diretamente",
+    description:
+      "Realize o investimento direto no projeto, sem intermediários, garantindo que 100% do valor chegue à causa.",
+  },
+  {
+    title: "4. Acompanhe o impacto",
+    description:
+      "Receba relatórios periódicos sobre o andamento do projeto e o impacto gerado pelo seu investimento.",
+  },
+]
+
+export function HowItWorksSection() {
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 sm:p-8 flex flex-col gap-6">
+      <h2 className="text-2xl font-medium leading-9 text-vinculo-dark">
+        Como funciona o Investimento Social Privado?
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-12 gap-y-6">
+        {STEPS.map((step) => (
+          <div key={step.title} className="flex flex-col gap-2">
+            <h3 className="text-base font-semibold text-vinculo-dark">{step.title}</h3>
+            <p className="text-sm text-slate-600 leading-6">{step.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/InterestThemesFilter.test.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/InterestThemesFilter.test.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { InterestThemesFilter } from "./InterestThemesFilter"
+import type { ThemeId } from "./mockData"
+
+const emptyCounts = {
+  educacao: 1, saude: 1, "meio-ambiente": 0, cultura: 0,
+  esporte: 0, inclusao: 1, "desenvolvimento-comunitario": 1,
+} as Record<ThemeId, number>
+
+describe("InterestThemesFilter", () => {
+  it("renderiza os 7 chips com contagem entre parênteses", () => {
+    render(<InterestThemesFilter selected={new Set()} onToggle={vi.fn()} counts={emptyCounts} />)
+    expect(screen.getByRole("button", { name: "Educação (1)" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Meio Ambiente (0)" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Desenvolvimento Comunitário (1)" })).toBeInTheDocument()
+  })
+
+  it("clicar num chip chama onToggle com o id correto", async () => {
+    const onToggle = vi.fn()
+    render(<InterestThemesFilter selected={new Set()} onToggle={onToggle} counts={emptyCounts} />)
+    await userEvent.click(screen.getByRole("button", { name: "Saúde (1)" }))
+    expect(onToggle).toHaveBeenCalledWith("saude")
+  })
+
+  it("chip presente no selected tem estilo ativo", () => {
+    const selected = new Set<ThemeId>(["inclusao"])
+    render(<InterestThemesFilter selected={selected} onToggle={vi.fn()} counts={emptyCounts} />)
+    const chip = screen.getByRole("button", { name: "Inclusão (1)" })
+    expect(chip.className).toContain("bg-vinculo-dark")
+  })
+
+  it("chip ausente do selected não tem estilo ativo", () => {
+    render(<InterestThemesFilter selected={new Set()} onToggle={vi.fn()} counts={emptyCounts} />)
+    const chip = screen.getByRole("button", { name: "Inclusão (1)" })
+    expect(chip.className).not.toContain("bg-vinculo-dark")
+  })
+})

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/InterestThemesFilter.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/InterestThemesFilter.tsx
@@ -1,0 +1,34 @@
+import { INVESTMENT_THEMES, type ThemeId } from "./mockData"
+
+interface InterestThemesFilterProps {
+  selected: Set<ThemeId>
+  onToggle: (id: ThemeId) => void
+  counts: Record<ThemeId, number>
+}
+
+export function InterestThemesFilter({ selected, onToggle, counts }: InterestThemesFilterProps) {
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 sm:p-8 flex flex-col gap-4">
+      <h2 className="text-base font-medium text-vinculo-dark">Temas de Interesse</h2>
+      <p className="text-sm text-slate-600">
+        Selecione os temas que mais se alinham com os valores e objetivos da sua empresa. Os
+        projetos serão filtrados automaticamente.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {INVESTMENT_THEMES.map((theme) => (
+          <button
+            key={theme.id}
+            onClick={() => onToggle(theme.id)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              selected.has(theme.id)
+                ? "bg-vinculo-dark text-white"
+                : "bg-vinculo-light-gray text-slate-700 hover:bg-slate-200"
+            }`}
+          >
+            {theme.label} ({counts[theme.id] ?? 0})
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/ProjectsGrid.test.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/ProjectsGrid.test.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { ProjectsGrid } from "./ProjectsGrid"
+import type { SocialEnrichedProject } from "./mockData"
+
+const mockProjects: SocialEnrichedProject[] = [
+  { id: 1, title: "Saúde em Movimento", description: "Desc", themes: ["saude"], primaryThemeLabel: "Saúde", targetAmount: 75000, progressPercent: 40, location: "Recife, PE" },
+  { id: 2, title: "Tecnologia Inclusiva", description: "Desc", themes: ["inclusao"], primaryThemeLabel: "Inclusão", targetAmount: 85000, progressPercent: 80, location: "Porto Alegre, RS" },
+]
+
+describe("ProjectsGrid (Investimento Social)", () => {
+  it("exibe estado de loading", () => {
+    render(<ProjectsGrid projects={[]} loading={true} error={null} />)
+    expect(screen.getByText("Carregando projetos...")).toBeInTheDocument()
+  })
+
+  it("exibe mensagem de erro", () => {
+    render(<ProjectsGrid projects={[]} loading={false} error="Timeout" />)
+    expect(screen.getByText(/Timeout/)).toBeInTheDocument()
+  })
+
+  it("exibe estado vazio para temas sem projetos", () => {
+    render(<ProjectsGrid projects={[]} loading={false} error={null} />)
+    expect(screen.getByText("Nenhum projeto encontrado para os temas selecionados.")).toBeInTheDocument()
+  })
+
+  it("renderiza título 'Todos os Projetos Sugeridos'", () => {
+    render(<ProjectsGrid projects={mockProjects} loading={false} error={null} />)
+    expect(screen.getByText("Todos os Projetos Sugeridos")).toBeInTheDocument()
+  })
+
+  it("renderiza os cards com títulos dos projetos", () => {
+    render(<ProjectsGrid projects={mockProjects} loading={false} error={null} />)
+    expect(screen.getByText("Saúde em Movimento")).toBeInTheDocument()
+    expect(screen.getByText("Tecnologia Inclusiva")).toBeInTheDocument()
+  })
+
+  it("exibe contagem de projetos encontrados", () => {
+    render(<ProjectsGrid projects={mockProjects} loading={false} error={null} />)
+    expect(screen.getByText("2 projetos encontrados")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/ProjectsGrid.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/ProjectsGrid.tsx
@@ -1,0 +1,71 @@
+import { ProjectCard } from "../../components/projects/ProjectCard"
+import type { SocialEnrichedProject } from "./mockData"
+
+interface ProjectsGridProps {
+  projects: SocialEnrichedProject[]
+  loading: boolean
+  error: string | null
+}
+
+export function ProjectsGrid({ projects, loading, error }: ProjectsGridProps) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex justify-between items-baseline flex-wrap gap-2">
+        <h2 className="text-2xl font-medium leading-9 text-vinculo-dark">
+          Todos os Projetos Sugeridos
+        </h2>
+        {!loading && !error && (
+          <span className="text-sm text-slate-500">
+            {projects.length}{" "}
+            {projects.length === 1 ? "projeto encontrado" : "projetos encontrados"}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <p className="text-slate-500 text-sm py-8 text-center">Carregando projetos...</p>
+      )}
+
+      {!loading && error && (
+        <p className="text-red-600 text-sm py-8 text-center">
+          Erro ao carregar projetos: {error}
+        </p>
+      )}
+
+      {!loading && !error && projects.length === 0 && (
+        <p className="text-slate-500 text-sm py-8 text-center">
+          Nenhum projeto encontrado para os temas selecionados.
+        </p>
+      )}
+
+      {!loading && !error && projects.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {projects.map((project) => (
+            <ProjectCard
+              key={project.id}
+              id={project.id}
+              title={project.title}
+              // TODO(backend): description vem mockada — ProjectListItemDTO precisa expor
+              //   'description' (já existe na entidade Project, basta incluir no DTO).
+              description={project.description}
+              // TODO(backend): tema do projeto (Saúde/Inclusão/etc) não existe na API.
+              //   ProjectListItemDTO não retorna categorias/temas. Atribuição mockada
+              //   por id % 7 em enrichProjectWithMocks.
+              type={project.primaryThemeLabel}
+              fundingType="investimento-social-privado"
+              // TODO(backend): targetAmount mockado — ProjectListItemDTO precisa expor
+              //   'budgetNeeded' (já existe na entidade Project).
+              targetAmount={project.targetAmount}
+              // TODO(backend): progressPercent mockado — backend deve calcular
+              //   (investedAmount / budgetNeeded * 100) e expor no DTO.
+              progressPercent={project.progressPercent}
+              // TODO(backend): location mockado — Project entity não tem cidade/estado.
+              //   Requer modelagem nova ou derivar do endereço da NPO responsável.
+              location={project.location}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/StatCardsRow.test.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/StatCardsRow.test.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { StatCardsRow } from "./StatCardsRow"
+
+describe("StatCardsRow (Investimento Social Privado)", () => {
+  it("exibe o count de projetos quando não está carregando", () => {
+    render(<StatCardsRow projectCount={2} loading={false} />)
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("exibe '—' quando está carregando", () => {
+    render(<StatCardsRow projectCount={2} loading={true} />)
+    expect(screen.getByText("—")).toBeInTheDocument()
+  })
+
+  it("exibe valores hardcoded de temas e match", () => {
+    render(<StatCardsRow projectCount={0} loading={false} />)
+    expect(screen.getByText("7")).toBeInTheDocument()
+    expect(screen.getByText("85%")).toBeInTheDocument()
+  })
+
+  it("renderiza os 3 labels", () => {
+    render(<StatCardsRow projectCount={0} loading={false} />)
+    expect(screen.getByText("Projetos sugeridos")).toBeInTheDocument()
+    expect(screen.getByText("Temas disponíveis")).toBeInTheDocument()
+    expect(screen.getByText("Match com seus interesses")).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/StatCardsRow.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/StatCardsRow.tsx
@@ -1,0 +1,39 @@
+import { MOCK_INTEREST_MATCH_PERCENT } from "./mockData"
+
+interface StatCardProps {
+  label: string
+  value: string
+  valueClassName?: string
+}
+
+function StatCard({ label, value, valueClassName = "text-vinculo-dark" }: StatCardProps) {
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6">
+      <p className="text-sm text-slate-500 mb-2">{label}</p>
+      <p className={`text-4xl font-bold ${valueClassName}`}>{value}</p>
+    </div>
+  )
+}
+
+interface StatCardsRowProps {
+  projectCount: number
+  loading: boolean
+}
+
+export function StatCardsRow({ projectCount, loading }: StatCardsRowProps) {
+  return (
+    <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <StatCard label="Projetos sugeridos" value={loading ? "—" : String(projectCount)} />
+      {/* TODO(backend): "Temas disponíveis" hoje hardcoded em 7 (comprimento de INVESTMENT_THEMES).
+          Não há endpoint que liste os temas disponíveis no sistema. */}
+      <StatCard label="Temas disponíveis" value="7" />
+      {/* TODO(backend): "Match com seus interesses" hoje hardcoded em MOCK_INTEREST_MATCH_PERCENT.
+          Backend deveria calcular afinidade entre interesses cadastrados da empresa e projetos. */}
+      <StatCard
+        label="Match com seus interesses"
+        value={`${MOCK_INTEREST_MATCH_PERCENT}%`}
+        valueClassName="text-vinculo-green"
+      />
+    </section>
+  )
+}

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/SuggestedProjectsBanner.test.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/SuggestedProjectsBanner.test.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { SuggestedProjectsBanner } from "./SuggestedProjectsBanner"
+
+describe("SuggestedProjectsBanner", () => {
+  it("usa singular quando projectCount=1", () => {
+    render(<SuggestedProjectsBanner projectCount={1} />)
+    expect(screen.getByText(/1 projeto que pode/)).toBeInTheDocument()
+  })
+
+  it("usa plural quando projectCount > 1", () => {
+    render(<SuggestedProjectsBanner projectCount={3} />)
+    expect(screen.getByText(/3 projetos que podem/)).toBeInTheDocument()
+  })
+
+  it("exibe os interesses mockados no texto", () => {
+    render(<SuggestedProjectsBanner projectCount={2} />)
+    expect(screen.getByText(/Educação, Meio Ambiente, Saúde/)).toBeInTheDocument()
+  })
+
+  it("renderiza o ícone de lâmpada e o título", () => {
+    render(<SuggestedProjectsBanner projectCount={0} />)
+    expect(screen.getByText(/Projetos Sugeridos/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/SuggestedProjectsBanner.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/SuggestedProjectsBanner.tsx
@@ -1,0 +1,22 @@
+import { MOCK_USER_INTEREST_LABELS } from "./mockData"
+
+interface SuggestedProjectsBannerProps {
+  projectCount: number
+}
+
+export function SuggestedProjectsBanner({ projectCount }: SuggestedProjectsBannerProps) {
+  return (
+    // TODO(backend): a lista de interesses "(Educação, Meio Ambiente, Saúde)" vem de
+    //   MOCK_USER_INTEREST_LABELS (hardcoded). Não existe endpoint para retornar os
+    //   interesses/temas cadastrados pela empresa logada.
+    <div className="bg-blue-50 border-l-4 border-vinculo-dark rounded-lg p-4 sm:p-6">
+      <h3 className="text-base font-semibold text-vinculo-dark mb-1">💡 Projetos Sugeridos</h3>
+      <p className="text-sm text-slate-700 leading-6">
+        Com base nos seus interesses cadastrados ({MOCK_USER_INTEREST_LABELS}), encontramos{" "}
+        {projectCount} {projectCount === 1 ? "projeto" : "projetos"} que{" "}
+        {projectCount === 1 ? "pode" : "podem"} ser do seu interesse. Use os filtros acima para
+        refinar sua busca.
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/index.test.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/index.test.tsx
@@ -1,0 +1,85 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { CompanyPrivateInvestmentPage } from "./index"
+
+const mocks = vi.hoisted(() => ({
+  fetchProjectsMock: vi.fn(),
+  getAccessTokenSilentlyMock: vi.fn(),
+}))
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: () => ({
+    getAccessTokenSilently: mocks.getAccessTokenSilentlyMock,
+    isAuthenticated: true,
+    isLoading: false,
+  }),
+}))
+
+vi.mock("../../api/projects", () => ({
+  fetchProjects: mocks.fetchProjectsMock,
+}))
+
+vi.mock("../../components/general/Header", () => ({
+  Header: () => <header data-testid="header" />,
+}))
+
+const makePageResponse = (items: { id: number; title: string }[]) => ({
+  content: items.map((p) => ({ id: p.id, title: p.title, status: "ACTIVE", npoId: 1, npoName: "ONG", npoPhone: "51999", startDate: "2026-01-01" })),
+  totalElements: items.length,
+  totalPages: 1, number: 0, size: 50, first: true, last: true,
+})
+
+describe("CompanyPrivateInvestmentPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getAccessTokenSilentlyMock.mockResolvedValue("token")
+    mocks.fetchProjectsMock.mockResolvedValue(makePageResponse([
+      { id: 1, title: "Saúde em Movimento" },
+      { id: 2, title: "Tecnologia Inclusiva" },
+    ]))
+  })
+
+  it("renderiza o título 'Investimento Social Privado'", () => {
+    render(<MemoryRouter><CompanyPrivateInvestmentPage /></MemoryRouter>)
+    expect(screen.getByText("Investimento Social Privado")).toBeInTheDocument()
+  })
+
+  it("renderiza o link 'Voltar ao Dashboard'", () => {
+    render(<MemoryRouter><CompanyPrivateInvestmentPage /></MemoryRouter>)
+    expect(screen.getByText("Voltar ao Dashboard")).toBeInTheDocument()
+  })
+
+  it("exibe os projetos retornados pela service", async () => {
+    render(<MemoryRouter><CompanyPrivateInvestmentPage /></MemoryRouter>)
+    await waitFor(() => {
+      expect(screen.getByText("Saúde em Movimento")).toBeInTheDocument()
+      expect(screen.getByText("Tecnologia Inclusiva")).toBeInTheDocument()
+    })
+  })
+
+  it("renderiza a seção 'Como funciona'", () => {
+    render(<MemoryRouter><CompanyPrivateInvestmentPage /></MemoryRouter>)
+    expect(screen.getByText("Como funciona o Investimento Social Privado?")).toBeInTheDocument()
+  })
+
+  it("exibe erro quando o fetch falha", async () => {
+    mocks.fetchProjectsMock.mockRejectedValue(new Error("Timeout"))
+    render(<MemoryRouter><CompanyPrivateInvestmentPage /></MemoryRouter>)
+    await waitFor(() => {
+      expect(screen.getByText(/Timeout/)).toBeInTheDocument()
+    })
+  })
+
+  it("clicar num chip de tema filtra os projetos (multi-select)", async () => {
+    render(<MemoryRouter><CompanyPrivateInvestmentPage /></MemoryRouter>)
+    await waitFor(() => expect(screen.getByText("Saúde em Movimento")).toBeInTheDocument())
+    // Usa name exato para evitar múltiplos matches com texto parcial
+    await userEvent.click(screen.getByRole("button", { name: /^Saúde \(/ }))
+    await waitFor(() => {
+      expect(screen.getAllByText(/projeto/).length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/index.tsx
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/index.tsx
@@ -1,0 +1,121 @@
+import { useAuth0 } from "@auth0/auth0-react"
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft"
+import { useEffect, useMemo, useState } from "react"
+import { Link } from "react-router-dom"
+import { fetchProjects, type ProjectListItem } from "../../api/projects"
+import { Header } from "../../components/general/Header"
+import { HowItWorksSection } from "./HowItWorksSection"
+import { InterestThemesFilter } from "./InterestThemesFilter"
+import { ProjectsGrid } from "./ProjectsGrid"
+import { StatCardsRow } from "./StatCardsRow"
+import { SuggestedProjectsBanner } from "./SuggestedProjectsBanner"
+import {
+  countProjectsByTheme,
+  enrichProjectWithMocks,
+  type ThemeId,
+} from "./mockData"
+
+export const CompanyPrivateInvestmentPage = () => {
+  const { getAccessTokenSilently } = useAuth0()
+  const [projects, setProjects] = useState<ProjectListItem[]>([])
+  const [totalElements, setTotalElements] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedThemes, setSelectedThemes] = useState<Set<ThemeId>>(new Set())
+
+  // Para demonstração com dados mockados: comente o useEffect abaixo.
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        setLoading(true)
+        const token = await getAccessTokenSilently()
+        const data = await fetchProjects(
+          { type: "SOCIAL_INVESTMENT_LAW", size: 50 },
+          token,
+        )
+        if (cancelled) return
+        setProjects(data.content)
+        setTotalElements(data.totalElements)
+        setError(null)
+      } catch (e) {
+        if (!cancelled)
+          setError(e instanceof Error ? e.message : "Erro ao carregar projetos")
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [getAccessTokenSilently])
+
+  // Para demonstração com dados mockados: comente a linha abaixo e descomente a seguinte.
+  const enriched = useMemo(
+    () => projects.map(enrichProjectWithMocks),
+    [projects],
+  )
+  // const enriched = MOCK_PROJECTS
+
+  const filtered = useMemo(() => {
+    if (selectedThemes.size === 0) return enriched
+    return enriched.filter((p) => p.themes.some((t) => selectedThemes.has(t)))
+  }, [enriched, selectedThemes])
+
+  const themeCounts = useMemo(() => countProjectsByTheme(enriched), [enriched])
+
+  const toggleTheme = (id: ThemeId) => {
+    setSelectedThemes((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex flex-col gap-10 pb-20">
+      <Header />
+      <main className="max-w-7xl mx-auto w-full px-4 sm:px-6 flex flex-col gap-6">
+        <Link
+          to="/empresa/dashboard"
+          className="flex items-center gap-1 text-sm text-vinculo-dark font-medium hover:opacity-70 transition-opacity w-fit"
+        >
+          <ChevronLeftIcon fontSize="small" />
+          Voltar ao Dashboard
+        </Link>
+
+        <header>
+          <h1 className="text-2xl font-medium leading-9 text-vinculo-dark">
+            Investimento Social Privado
+          </h1>
+          <p className="text-base font-normal leading-6 text-slate-600 max-w-xl">
+            Invista diretamente em projetos sociais alinhados com os valores e
+            objetivos da sua empresa. Projetos sugeridos com base nos seus temas
+            de interesse cadastrados.
+          </p>
+        </header>
+
+        {/* Para demonstração: trocar `totalElements` por `MOCK_PROJECTS.length` e `loading` por `false` */}
+        <StatCardsRow projectCount={totalElements} loading={loading} />
+
+        <InterestThemesFilter
+          selected={selectedThemes}
+          onToggle={toggleTheme}
+          counts={themeCounts}
+        />
+
+        <SuggestedProjectsBanner projectCount={filtered.length} />
+
+        {/* Para demonstração: trocar `loading` por `false` e `error` por `null` */}
+        <ProjectsGrid projects={filtered} loading={loading} error={error} />
+
+        <HowItWorksSection />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/mockData.test.ts
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/mockData.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import {
+  countProjectsByTheme,
+  enrichProjectWithMocks,
+  INVESTMENT_THEMES,
+  MOCK_USER_INTEREST_LABELS,
+  MOCK_USER_INTERESTS,
+  type SocialEnrichedProject,
+} from "./mockData"
+import type { ProjectListItem } from "../../api/projects"
+
+const baseProject: ProjectListItem = {
+  id: 0,
+  title: "Projeto Teste",
+  status: "ACTIVE",
+  npoId: 1,
+  npoName: "ONG Teste",
+  npoPhone: "51999",
+  startDate: "2026-01-01",
+}
+
+describe("enrichProjectWithMocks", () => {
+  it("preserva id e title do projeto original", () => {
+    const result = enrichProjectWithMocks({ ...baseProject, id: 5, title: "Social Teste" })
+    expect(result.id).toBe(5)
+    expect(result.title).toBe("Social Teste")
+  })
+
+  it("atribui tema deterministicamente: id=0 → educacao (índice 0)", () => {
+    const result = enrichProjectWithMocks({ ...baseProject, id: 0 })
+    expect(result.themes).toContain("educacao")
+    expect(result.primaryThemeLabel).toBe("Educação")
+  })
+
+  it("atribui tema deterministicamente: id=1 → saude (índice 1)", () => {
+    const result = enrichProjectWithMocks({ ...baseProject, id: 1 })
+    expect(result.themes).toContain("saude")
+  })
+
+  it("cicla o tema com módulo 7: id=7 → mesmo que id=0 (educacao)", () => {
+    const r0 = enrichProjectWithMocks({ ...baseProject, id: 0 })
+    const r7 = enrichProjectWithMocks({ ...baseProject, id: 7 })
+    expect(r7.themes).toEqual(r0.themes)
+    expect(r7.primaryThemeLabel).toBe(r0.primaryThemeLabel)
+  })
+
+  it("preenche campos placeholders com valores constantes", () => {
+    const result = enrichProjectWithMocks(baseProject)
+    expect(result.targetAmount).toBe(50000)
+    expect(result.progressPercent).toBe(50)
+    expect(result.location).toBe("Brasil")
+    expect(result.description).toBeTruthy()
+  })
+})
+
+describe("countProjectsByTheme", () => {
+  it("retorna zero para todos os temas com lista vazia", () => {
+    const counts = countProjectsByTheme([])
+    for (const theme of INVESTMENT_THEMES) {
+      expect(counts[theme.id]).toBe(0)
+    }
+  })
+
+  it("conta corretamente para projetos com múltiplos temas", () => {
+    const projects: SocialEnrichedProject[] = [
+      { id: 1, title: "", description: "", themes: ["saude", "desenvolvimento-comunitario"], primaryThemeLabel: "", targetAmount: 0, progressPercent: 0, location: "" },
+      { id: 2, title: "", description: "", themes: ["inclusao", "educacao"], primaryThemeLabel: "", targetAmount: 0, progressPercent: 0, location: "" },
+    ]
+    const counts = countProjectsByTheme(projects)
+    expect(counts["saude"]).toBe(1)
+    expect(counts["desenvolvimento-comunitario"]).toBe(1)
+    expect(counts["inclusao"]).toBe(1)
+    expect(counts["educacao"]).toBe(1)
+    expect(counts["cultura"]).toBe(0)
+  })
+})
+
+describe("MOCK_USER_INTEREST_LABELS", () => {
+  it("gera string com labels dos interesses mockados", () => {
+    expect(MOCK_USER_INTEREST_LABELS).toBe("Educação, Meio Ambiente, Saúde")
+  })
+
+  it("MOCK_USER_INTERESTS contém 3 temas", () => {
+    expect(MOCK_USER_INTERESTS).toHaveLength(3)
+  })
+})

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/mockData.ts
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/mockData.ts
@@ -1,0 +1,104 @@
+import type { ProjectListItem } from "../../api/projects"
+
+export const INVESTMENT_THEMES = [
+  { id: "educacao", label: "Educação" },
+  { id: "saude", label: "Saúde" },
+  { id: "meio-ambiente", label: "Meio Ambiente" },
+  { id: "cultura", label: "Cultura" },
+  { id: "esporte", label: "Esporte" },
+  { id: "inclusao", label: "Inclusão" },
+  { id: "desenvolvimento-comunitario", label: "Desenvolvimento Comunitário" },
+] as const
+
+export type ThemeId = (typeof INVESTMENT_THEMES)[number]["id"]
+
+// TODO(backend): interesses do usuário hoje hardcoded.
+//   Não existe endpoint para retornar os temas/interesses cadastrados pela empresa logada.
+//   Quando existir, substituir por GET /api/me/company/interests ou similar.
+export const MOCK_USER_INTERESTS: ThemeId[] = ["educacao", "meio-ambiente", "saude"]
+
+export const MOCK_USER_INTEREST_LABELS = MOCK_USER_INTERESTS
+  .map((id) => INVESTMENT_THEMES.find((t) => t.id === id)?.label ?? id)
+  .join(", ")
+
+// TODO(backend): "Match com seus interesses" hoje hardcoded em 85%.
+//   Backend deveria calcular esse percentual com base na sobreposição entre
+//   interesses cadastrados da empresa e temas dos projetos disponíveis.
+export const MOCK_INTEREST_MATCH_PERCENT = 85
+
+export interface SocialEnrichedProject {
+  id: number
+  title: string
+  description: string
+  themes: ThemeId[]
+  primaryThemeLabel: string
+  targetAmount: number
+  progressPercent: number
+  location: string
+}
+
+// Projetos mockados para demonstração — remover quando usar a service real.
+export const MOCK_PROJECTS: SocialEnrichedProject[] = [
+  {
+    id: 1,
+    title: "Saúde em Movimento",
+    description:
+      "Unidade móvel de saúde para atendimento médico e odontológico em comunidades rurais.",
+    themes: ["saude", "desenvolvimento-comunitario"],
+    primaryThemeLabel: "Saúde",
+    targetAmount: 75000,
+    progressPercent: 40,
+    location: "Recife, PE",
+  },
+  {
+    id: 2,
+    title: "Tecnologia Inclusiva",
+    description:
+      "Laboratório de tecnologia adaptativa para pessoas com deficiência, oferecendo formação e oportunidades no mercado de trabalho.",
+    themes: ["inclusao", "educacao"],
+    primaryThemeLabel: "Inclusão",
+    targetAmount: 85000,
+    progressPercent: 80,
+    location: "Porto Alegre, RS",
+  },
+]
+
+// TODO(backend): atribuição de temas mockada deterministicamente (id % 7).
+//   ProjectListItemDTO precisa expor um array de temas (ex.: "themes": string[]).
+//   Hoje o DTO não retorna nada relacionado a categorias ou temas.
+export function enrichProjectWithMocks(project: ProjectListItem): SocialEnrichedProject {
+  const themeIndex = project.id % INVESTMENT_THEMES.length
+  const theme = INVESTMENT_THEMES[themeIndex]
+  return {
+    id: project.id,
+    title: project.title,
+    // TODO(backend): description não existe em ProjectListItemDTO.
+    //   Adicionar campo 'description' ao DTO (já existe na entidade Project).
+    description: "Apoie este projeto investindo diretamente na causa, sem intermediários.",
+    themes: [theme.id],
+    primaryThemeLabel: theme.label,
+    // TODO(backend): targetAmount não existe em ProjectListItemDTO.
+    //   Adicionar campo 'budgetNeeded' ao DTO (já existe na entidade Project).
+    targetAmount: 50000,
+    // TODO(backend): progressPercent não existe em ProjectListItemDTO.
+    //   Backend deve calcular (investedAmount / budgetNeeded * 100) e expor no DTO.
+    progressPercent: 50,
+    // TODO(backend): location não existe em ProjectListItemDTO.
+    //   Project entity não tem cidade/estado — requer modelagem nova ou endereço da NPO.
+    location: "Brasil",
+  }
+}
+
+export function countProjectsByTheme(
+  projects: SocialEnrichedProject[],
+): Record<ThemeId, number> {
+  const counts = Object.fromEntries(
+    INVESTMENT_THEMES.map((t) => [t.id, 0]),
+  ) as Record<ThemeId, number>
+  for (const p of projects) {
+    for (const t of p.themes) {
+      counts[t]++
+    }
+  }
+  return counts
+}

--- a/frontend/src/router/index.tsx
+++ b/frontend/src/router/index.tsx
@@ -8,6 +8,7 @@ import { ProtectedRoute } from "../components/auth/ProtectedRoute"
 import { RoleHomePage } from "../pages/RoleHomePage"
 import { CompanyRegistrationPage } from "../pages/CompanyRegistration/registration"
 import { CompanyDashboard } from "../pages/CompanyDashboard"
+import { CompanyPrivateInvestmentPage } from "../pages/CompanyPrivateInvestmentPage"
 
 export const AppRouter = () => (
   <BrowserRouter>
@@ -45,6 +46,14 @@ export const AppRouter = () => (
         element={
           <ProtectedRoute requiredRole="COMPANY">
             <CompanyDashboard />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/empresa/investimento-social-privado"
+        element={
+          <ProtectedRoute requiredRole="COMPANY">
+            <CompanyPrivateInvestmentPage />
           </ProtectedRoute>
         }
       />


### PR DESCRIPTION
## Issue Link
Closes https://github.com/VinculoHub-Portal/VinculoHubPortal/issues/148

## Description
Adiciona página de Investimento Social Privado (rota /empresa/investimento-social-privado) com filtro por tema de interesse, grid de projetos, stat cards, banner de projetos sugeridos e seção "Como funciona". Inclui módulo compartilhado api/projects.ts e infraestrutura de tipos para testes.

Inclui também o fix de deep-link returnTo em AuthRoleRedirect/main.tsx necessário para que a página seja acessível via deep-link após login.

Pequenos fixes de TS:
- Tipa explicitamente os projetos no teste de countProjectsByTheme.
- Cast explícito em resolveLogin?.() em RegisterPage/index.test.tsx.

## Task Notes
## Screenshots
<img width="2954" height="2660" alt="localhost_5173__code=th1PIKj_bDi9wB_5tZaJ7a7I78SFlsH4z5KMh1rgDVEY0 state=dGN6X3NLaUpISTJHa0dkMWFxQy5wUnBpbnBnZmpsb0NXSkpiUU44c0xJdA%3D%3D" src="https://github.com/user-attachments/assets/ee819495-4015-4aa6-b8e9-71aa41491a5c" />
