### PR TITLE
fix: restore project compatibility after integration merge

### DIFF
--- a/backend/src/main/java/com/vinculohub/backend/controller/ProjectController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/ProjectController.java
@@ -97,10 +97,16 @@ public class ProjectController {
                 project.getTitle(),
                 project.getDescription(),
                 project.getStatus().name(),
+                project.getType(),
                 project.getBudgetNeeded(),
                 project.getInvestedAmount(),
                 ods,
                 project.getStartDate(),
-                project.getEndDate());
+                project.getEndDate(),
+                project.getFocusArea(),
+                project.getFundraisingDeadline(),
+                project.getBeneficiariesCount(),
+                project.getLocation(),
+                project.getMainObjective());
     }
 }

--- a/backend/src/main/java/com/vinculohub/backend/dto/ProjectDetailResponse.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/ProjectDetailResponse.java
@@ -1,6 +1,7 @@
 /* (C)2026 */
 package com.vinculohub.backend.dto;
 
+import com.vinculohub.backend.model.enums.ProjectType;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
@@ -10,8 +11,14 @@ public record ProjectDetailResponse(
         String title,
         String description,
         String status,
+        ProjectType type,
         BigDecimal budgetNeeded,
         BigDecimal investedAmount,
         List<OdsResponse> ods,
         LocalDate startDate,
-        LocalDate endDate) {}
+        LocalDate endDate,
+        String focusArea,
+        String fundraisingDeadline,
+        Integer beneficiariesCount,
+        String location,
+        String mainObjective) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/ProjectListItemDTO.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/ProjectListItemDTO.java
@@ -3,25 +3,45 @@ package com.vinculohub.backend.dto;
 
 import com.vinculohub.backend.model.Project;
 import com.vinculohub.backend.model.enums.ProjectStatus;
+import com.vinculohub.backend.model.enums.ProjectType;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record ProjectListItemDTO(
         Long id,
         String title,
+        String description,
         ProjectStatus status,
+        ProjectType type,
         Integer npoId,
         String npoName,
         String npoPhone,
-        LocalDate startDate) {
+        LocalDate startDate,
+        BigDecimal budgetNeeded,
+        BigDecimal investedAmount,
+        String focusArea,
+        String fundraisingDeadline,
+        Integer beneficiariesCount,
+        String location,
+        String mainObjective) {
 
     public static ProjectListItemDTO from(Project project) {
         return new ProjectListItemDTO(
                 project.getId(),
                 project.getTitle(),
+                project.getDescription(),
                 project.getStatus(),
+                project.getType(),
                 project.getNpo().getId(),
                 project.getNpo().getName(),
                 project.getNpo().getPhone(),
-                project.getStartDate());
+                project.getStartDate(),
+                project.getBudgetNeeded(),
+                project.getInvestedAmount(),
+                project.getFocusArea(),
+                project.getFundraisingDeadline(),
+                project.getBeneficiariesCount(),
+                project.getLocation(),
+                project.getMainObjective());
     }
 }

--- a/backend/src/main/java/com/vinculohub/backend/model/enums/ProjectType.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/enums/ProjectType.java
@@ -2,6 +2,8 @@
 package com.vinculohub.backend.model.enums;
 
 public enum ProjectType {
+    SOCIAL_INVESTMENT_LAW,
+    TAX_INCENTIVE_LAW,
     SOCIAL,
     GOVERNMENTAL,
     CULTURAL,

--- a/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
@@ -78,7 +78,9 @@ class ProjectControllerTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content[0].title").value("Projeto Alpha"))
+                .andExpect(jsonPath("$.content[0].description").value("Descrição do projeto"))
                 .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
+                .andExpect(jsonPath("$.content[0].focusArea").value("educacao"))
                 .andExpect(jsonPath("$.content[0].npoName").value("ONG Teste"))
                 .andExpect(jsonPath("$.totalElements").value(1));
     }
@@ -271,6 +273,77 @@ class ProjectControllerTest extends AbstractIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.content[0].title").value("Projeto Cultural"));
+    }
+
+    @Test
+    @DisplayName(
+            "GET /api/projects?type=TAX_INCENTIVE_LAW mantém compatibilidade com tipos antigos")
+    void shouldFilterByLegacyProjectType() throws Exception {
+        projectRepository.save(
+                Project.builder()
+                        .npo(npo)
+                        .title("Projeto Lei de Incentivo")
+                        .description("D")
+                        .focusArea("educacao")
+                        .type(ProjectType.TAX_INCENTIVE_LAW)
+                        .build());
+        projectRepository.save(
+                Project.builder()
+                        .npo(npo)
+                        .title("Projeto Social")
+                        .description("D")
+                        .focusArea("educacao")
+                        .type(ProjectType.SOCIAL)
+                        .build());
+
+        mockMvc.perform(
+                        get("/api/projects?type=TAX_INCENTIVE_LAW")
+                                .with(
+                                        jwt().authorities(
+                                                        new SimpleGrantedAuthority(
+                                                                "ROLE_COMPANY"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].title").value("Projeto Lei de Incentivo"));
+    }
+
+    @Test
+    @DisplayName("GET /api/projects/{id} retorna detalhe com os novos campos do projeto")
+    void shouldReturnProjectDetailWithNewFields() throws Exception {
+        Project project =
+                projectRepository.save(
+                        Project.builder()
+                                .npo(npo)
+                                .title("Projeto Detalhado")
+                                .description("Descrição detalhada do projeto")
+                                .status(ProjectStatus.ACTIVE)
+                                .type(ProjectType.CULTURAL)
+                                .budgetNeeded(java.math.BigDecimal.valueOf(120000))
+                                .investedAmount(java.math.BigDecimal.valueOf(15000))
+                                .focusArea("cultura")
+                                .fundraisingDeadline("6 meses")
+                                .beneficiariesCount(300)
+                                .location("Porto Alegre, RS")
+                                .mainObjective("Ampliar acesso à cultura.")
+                                .ods(Set.of(ods1, ods3))
+                                .startDate(LocalDate.of(2026, 1, 15))
+                                .endDate(LocalDate.of(2026, 12, 15))
+                                .build());
+
+        mockMvc.perform(
+                        get("/api/projects/" + project.getId())
+                                .with(
+                                        jwt().authorities(
+                                                        new SimpleGrantedAuthority(
+                                                                "ROLE_COMPANY"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Projeto Detalhado"))
+                .andExpect(jsonPath("$.type").value("CULTURAL"))
+                .andExpect(jsonPath("$.focusArea").value("cultura"))
+                .andExpect(jsonPath("$.fundraisingDeadline").value("6 meses"))
+                .andExpect(jsonPath("$.beneficiariesCount").value(300))
+                .andExpect(jsonPath("$.location").value("Porto Alegre, RS"))
+                .andExpect(jsonPath("$.mainObjective").value("Ampliar acesso à cultura."));
     }
 
     @Test

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -2,16 +2,31 @@ import { api } from "../services/api"
 import { logger } from "../utils/logger"
 
 export type ProjectStatus = "ACTIVE" | "COMPLETED" | "CANCELLED"
-export type ProjectType = "SOCIAL_INVESTMENT_LAW" | "TAX_INCENTIVE_LAW"
+export type ProjectType =
+  | "SOCIAL_INVESTMENT_LAW"
+  | "TAX_INCENTIVE_LAW"
+  | "SOCIAL"
+  | "GOVERNMENTAL"
+  | "CULTURAL"
+  | "ENVIRONMENTAL"
 
 export interface ProjectListItem {
   id: number
   title: string
+  description?: string
   status: ProjectStatus
+  type?: ProjectType | null
   npoId: number
   npoName: string
   npoPhone: string
   startDate: string
+  budgetNeeded?: number | null
+  investedAmount?: number | null
+  focusArea?: string | null
+  fundraisingDeadline?: string | null
+  beneficiariesCount?: number | null
+  location?: string | null
+  mainObjective?: string | null
 }
 
 export interface PageResponse<T> {
@@ -75,10 +90,16 @@ export interface CreateProjectResponse {
   title: string
   description: string
   status: ProjectStatus
+  type?: ProjectType | null
   budgetNeeded: number | null
   investedAmount: number | null
   startDate: string | null
   endDate: string | null
+  focusArea?: string | null
+  fundraisingDeadline?: string | null
+  beneficiariesCount?: number | null
+  location?: string | null
+  mainObjective?: string | null
 }
 
 export async function createProject(

--- a/frontend/src/pages/CompanyIncentiveLawsPage/mockData.ts
+++ b/frontend/src/pages/CompanyIncentiveLawsPage/mockData.ts
@@ -100,23 +100,21 @@ export const MOCK_PROJECTS: EnrichedProject[] = [
 //   ProjectType hoje só tem TAX_INCENTIVE_LAW / SOCIAL_INVESTMENT_LAW — sem granularidade.
 export function enrichProjectWithMocks(project: ProjectListItem): EnrichedProject {
   const law = SPECIFIC_LAWS[project.id % SPECIFIC_LAWS.length]
+  const targetAmount = project.budgetNeeded ?? 50000
+  const progressPercent =
+    project.budgetNeeded && project.budgetNeeded > 0 && project.investedAmount != null
+      ? Math.round((project.investedAmount / project.budgetNeeded) * 100)
+      : 50
   return {
     id: project.id,
     title: project.title,
-    // TODO(backend): description não existe em ProjectListItemDTO.
-    //   Adicionar campo 'description' ao DTO (já existe na entidade Project).
     description:
+      project.description ||
       "Apoie este projeto através de leis de incentivo fiscal e obtenha benefícios tributários para sua empresa.",
     lawId: law.id,
     lawLabel: law.label,
-    // TODO(backend): targetAmount não existe em ProjectListItemDTO.
-    //   Adicionar campo 'budgetNeeded' (já existe na entidade Project) ao DTO.
-    targetAmount: 50000,
-    // TODO(backend): progressPercent não existe em ProjectListItemDTO.
-    //   Calcular no backend como (investedAmount / budgetNeeded * 100) e expor no DTO.
-    progressPercent: 50,
-    // TODO(backend): location não existe em ProjectListItemDTO.
-    //   Project entity não tem cidade/estado — requer modelagem nova ou relacionamento com endereço da ONG.
-    location: "Brasil",
+    targetAmount,
+    progressPercent,
+    location: project.location || "Brasil",
   }
 }

--- a/frontend/src/pages/CompanyPrivateInvestmentPage/mockData.ts
+++ b/frontend/src/pages/CompanyPrivateInvestmentPage/mockData.ts
@@ -69,23 +69,22 @@ export const MOCK_PROJECTS: SocialEnrichedProject[] = [
 export function enrichProjectWithMocks(project: ProjectListItem): SocialEnrichedProject {
   const themeIndex = project.id % INVESTMENT_THEMES.length
   const theme = INVESTMENT_THEMES[themeIndex]
+  const targetAmount = project.budgetNeeded ?? 50000
+  const progressPercent =
+    project.budgetNeeded && project.budgetNeeded > 0 && project.investedAmount != null
+      ? Math.round((project.investedAmount / project.budgetNeeded) * 100)
+      : 50
   return {
     id: project.id,
     title: project.title,
-    // TODO(backend): description não existe em ProjectListItemDTO.
-    //   Adicionar campo 'description' ao DTO (já existe na entidade Project).
-    description: "Apoie este projeto investindo diretamente na causa, sem intermediários.",
+    description:
+      project.description ||
+      "Apoie este projeto investindo diretamente na causa, sem intermediários.",
     themes: [theme.id],
     primaryThemeLabel: theme.label,
-    // TODO(backend): targetAmount não existe em ProjectListItemDTO.
-    //   Adicionar campo 'budgetNeeded' ao DTO (já existe na entidade Project).
-    targetAmount: 50000,
-    // TODO(backend): progressPercent não existe em ProjectListItemDTO.
-    //   Backend deve calcular (investedAmount / budgetNeeded * 100) e expor no DTO.
-    progressPercent: 50,
-    // TODO(backend): location não existe em ProjectListItemDTO.
-    //   Project entity não tem cidade/estado — requer modelagem nova ou endereço da NPO.
-    location: "Brasil",
+    targetAmount,
+    progressPercent,
+    location: project.location || "Brasil",
   }
 }
 


### PR DESCRIPTION
## Issue Link
Closes #

## Description
Corrige regressões introduzidas após o merge da integração de criação de projetos, restaurando a compatibilidade entre frontend e backend nas rotas de projetos.

Principais ajustes:
- restaura compatibilidade do `ProjectType`, aceitando tanto os valores antigos (`SOCIAL_INVESTMENT_LAW`, `TAX_INCENTIVE_LAW`) quanto os novos;
- atualiza as rotas de listagem e detalhe de projetos para retornarem os novos campos adicionados na entidade `Project`;
- ajusta os DTOs de resposta do backend para expor esses campos corretamente;
- atualiza os tipos do frontend para refletirem o contrato atual da API;
- adapta os mocks das páginas de empresa para aproveitarem dados reais da API quando disponíveis;
- adiciona cobertura de testes para compatibilidade de tipo legado e retorno dos novos campos.

## Task Notes
Essa correção foi necessária porque a alteração anterior no enum `ProjectType` e na entidade `Project` deixou o frontend incompatível com os filtros antigos e também não refletiu os novos campos nas rotas `listagem` e `getById`.

## Validation
- `frontend`: `npm run build`
- `backend`: `./mvnw -Dtest=ProjectControllerTest,ProjectServiceTest test`
- `backend`: `./mvnw -DskipTests spotless:check`

## Screenshots
N/A