### PR TITLE
feat: implement edital backend layer (#209)

### DIFF
--- a/backend/src/main/java/com/vinculohub/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/SecurityConfig.java
@@ -57,6 +57,8 @@ public class SecurityConfig {
                                         .permitAll()
                                         .requestMatchers("/cep/**", "/cnpj/**")
                                         .permitAll()
+                                        .requestMatchers(HttpMethod.GET, "/api/editais")
+                                        .permitAll()
                                         .requestMatchers("/api/documents/**")
                                         .authenticated()
                                         .anyRequest()

--- a/backend/src/main/java/com/vinculohub/backend/controller/EditalController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/EditalController.java
@@ -1,0 +1,35 @@
+/* (C)2026 */
+package com.vinculohub.backend.controller;
+
+import com.vinculohub.backend.dto.EditalRequestDTO;
+import com.vinculohub.backend.dto.EditalResponseDTO;
+import com.vinculohub.backend.service.EditalService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/editais")
+@RequiredArgsConstructor
+public class EditalController {
+
+    private final EditalService editalService;
+
+    @PostMapping(consumes = "multipart/form-data")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<EditalResponseDTO> create(
+            @RequestPart("file") MultipartFile file,
+            @RequestPart("data") EditalRequestDTO dto) {
+        EditalResponseDTO response = editalService.create(file, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<EditalResponseDTO>> listAll() {
+        return ResponseEntity.ok(editalService.findAll());
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/controller/EditalController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/EditalController.java
@@ -22,8 +22,7 @@ public class EditalController {
     @PostMapping(consumes = "multipart/form-data")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<EditalResponseDTO> create(
-            @RequestPart("file") MultipartFile file,
-            @RequestPart("data") EditalRequestDTO dto) {
+            @RequestPart("file") MultipartFile file, @RequestPart("data") EditalRequestDTO dto) {
         EditalResponseDTO response = editalService.create(file, dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/backend/src/main/java/com/vinculohub/backend/dto/EditalRequestDTO.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/EditalRequestDTO.java
@@ -2,5 +2,6 @@
 package com.vinculohub.backend.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 
-public record EditalRequestDTO(@NotBlank String title, String description) {}
+public record EditalRequestDTO(@NotBlank String title, String description, List<Integer> odsIds) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/EditalRequestDTO.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/EditalRequestDTO.java
@@ -1,0 +1,6 @@
+/* (C)2026 */
+package com.vinculohub.backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EditalRequestDTO(@NotBlank String title, String description) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/EditalResponseDTO.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/EditalResponseDTO.java
@@ -2,6 +2,7 @@
 package com.vinculohub.backend.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record EditalResponseDTO(
         Long id,
@@ -11,6 +12,7 @@ public record EditalResponseDTO(
         String fileName,
         Long fileSize,
         String mimeType,
+        List<OdsResponse> ods,
         LocalDateTime expiredAt,
         LocalDateTime createdAt,
         LocalDateTime updatedAt) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/EditalResponseDTO.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/EditalResponseDTO.java
@@ -11,5 +11,6 @@ public record EditalResponseDTO(
         String fileName,
         Long fileSize,
         String mimeType,
+        LocalDateTime expiredAt,
         LocalDateTime createdAt,
         LocalDateTime updatedAt) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/EditalResponseDTO.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/EditalResponseDTO.java
@@ -1,0 +1,15 @@
+/* (C)2026 */
+package com.vinculohub.backend.dto;
+
+import java.time.LocalDateTime;
+
+public record EditalResponseDTO(
+        Long id,
+        String title,
+        String description,
+        String fileUrl,
+        String fileName,
+        Long fileSize,
+        String mimeType,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt) {}

--- a/backend/src/main/java/com/vinculohub/backend/model/Edital.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/Edital.java
@@ -3,6 +3,8 @@ package com.vinculohub.backend.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
@@ -45,6 +47,13 @@ public class Edital {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "edital_ods",
+            joinColumns = @JoinColumn(name = "edital_id"),
+            inverseJoinColumns = @JoinColumn(name = "ods_id"))
+    private Set<Ods> ods = new LinkedHashSet<>();
 
     @Column(name = "expired_at")
     private LocalDateTime expiredAt;

--- a/backend/src/main/java/com/vinculohub/backend/model/Edital.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/Edital.java
@@ -46,6 +46,9 @@ public class Edital {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 }

--- a/backend/src/main/java/com/vinculohub/backend/model/Edital.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/Edital.java
@@ -1,0 +1,51 @@
+/* (C)2026 */
+package com.vinculohub.backend.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "edital")
+@SQLRestriction("deleted_at IS NULL")
+public class Edital {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(length = 500)
+    private String description;
+
+    @Column(name = "file_url", length = 500, nullable = false)
+    private String fileUrl;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @Column(name = "mime_type", nullable = false)
+    private String mimeType;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/backend/src/main/java/com/vinculohub/backend/repository/EditalRepository.java
+++ b/backend/src/main/java/com/vinculohub/backend/repository/EditalRepository.java
@@ -1,0 +1,9 @@
+/* (C)2026 */
+package com.vinculohub.backend.repository;
+
+import com.vinculohub.backend.model.Edital;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EditalRepository extends JpaRepository<Edital, Long> {}

--- a/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
@@ -3,13 +3,16 @@ package com.vinculohub.backend.service;
 
 import com.vinculohub.backend.dto.EditalRequestDTO;
 import com.vinculohub.backend.dto.EditalResponseDTO;
+import com.vinculohub.backend.dto.OdsResponse;
 import com.vinculohub.backend.exception.FileFormatValidationException;
 import com.vinculohub.backend.exception.FileSizeValidationException;
 import com.vinculohub.backend.model.Edital;
+import com.vinculohub.backend.model.Ods;
 import com.vinculohub.backend.repository.EditalRepository;
 import com.vinculohub.backend.service.storage.S3Uploader;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,7 @@ public class EditalService {
 
     private final EditalRepository editalRepository;
     private final S3Uploader s3Uploader;
+    private final OdsService odsService;
 
     private static final long MAX_FILE_SIZE = 10L * 1024 * 1024;
     private static final String ALLOWED_TYPE = "application/pdf";
@@ -44,6 +48,13 @@ public class EditalService {
             throw new RuntimeException("Storage upload failed: ", e);
         }
 
+        Set<Ods> ods = Set.of();
+        if (dto.odsIds() != null && !dto.odsIds().isEmpty()) {
+            List<String> odsStringIds =
+                    dto.odsIds().stream().map(String::valueOf).toList();
+            ods = odsService.resolveSelection(odsStringIds);
+        }
+
         Edital edital = new Edital();
         edital.setTitle(dto.title());
         edital.setDescription(dto.description());
@@ -51,6 +62,7 @@ public class EditalService {
         edital.setFileName(UUID.randomUUID() + "_" + file.getOriginalFilename());
         edital.setFileSize(file.getSize());
         edital.setMimeType(file.getContentType());
+        edital.setOds(ods);
 
         return mapToResponse(editalRepository.save(edital));
     }
@@ -63,6 +75,12 @@ public class EditalService {
     }
 
     private EditalResponseDTO mapToResponse(Edital edital) {
+        Set<Ods> odsSet = edital.getOds() == null ? Set.of() : edital.getOds();
+        List<OdsResponse> odsList =
+                odsSet.stream()
+                        .map(o -> new OdsResponse(o.getId(), o.getName(), o.getDescription()))
+                        .toList();
+
         return new EditalResponseDTO(
                 edital.getId(),
                 edital.getTitle(),
@@ -71,6 +89,7 @@ public class EditalService {
                 edital.getFileName(),
                 edital.getFileSize(),
                 edital.getMimeType(),
+                odsList,
                 edital.getExpiredAt(),
                 edital.getCreatedAt(),
                 edital.getUpdatedAt());

--- a/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
@@ -1,0 +1,77 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import com.vinculohub.backend.dto.EditalRequestDTO;
+import com.vinculohub.backend.dto.EditalResponseDTO;
+import com.vinculohub.backend.exception.FileFormatValidationException;
+import com.vinculohub.backend.exception.FileSizeValidationException;
+import com.vinculohub.backend.model.Edital;
+import com.vinculohub.backend.repository.EditalRepository;
+import com.vinculohub.backend.service.storage.S3Uploader;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class EditalService {
+
+    private final EditalRepository editalRepository;
+    private final S3Uploader s3Uploader;
+
+    private static final long MAX_FILE_SIZE = 10L * 1024 * 1024;
+    private static final String ALLOWED_TYPE = "application/pdf";
+
+    @Transactional
+    public EditalResponseDTO create(MultipartFile file, EditalRequestDTO dto) {
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new FileSizeValidationException("File exceeds 10MB limit");
+        }
+
+        if (!ALLOWED_TYPE.equals(file.getContentType())) {
+            throw new FileFormatValidationException("Only PDF files are allowed");
+        }
+
+        String fileUrl;
+        try {
+            fileUrl = s3Uploader.uploadFile(file, "editais");
+        } catch (IOException e) {
+            throw new RuntimeException("Storage upload failed: ", e);
+        }
+
+        Edital edital = new Edital();
+        edital.setTitle(dto.title());
+        edital.setDescription(dto.description());
+        edital.setFileUrl(fileUrl);
+        edital.setFileName(UUID.randomUUID() + "_" + file.getOriginalFilename());
+        edital.setFileSize(file.getSize());
+        edital.setMimeType(file.getContentType());
+
+        return mapToResponse(editalRepository.save(edital));
+    }
+
+    @Transactional(readOnly = true)
+    public List<EditalResponseDTO> findAll() {
+        return editalRepository.findAll().stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    private EditalResponseDTO mapToResponse(Edital edital) {
+        return new EditalResponseDTO(
+                edital.getId(),
+                edital.getTitle(),
+                edital.getDescription(),
+                edital.getFileUrl(),
+                edital.getFileName(),
+                edital.getFileSize(),
+                edital.getMimeType(),
+                edital.getCreatedAt(),
+                edital.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
@@ -29,7 +29,16 @@ public class EditalService {
     private final OdsService odsService;
 
     private static final long MAX_FILE_SIZE = 10L * 1024 * 1024;
-    private static final String ALLOWED_TYPE = "application/pdf";
+    private static final Set<String> ALLOWED_TYPES = Set.of(
+    "application/pdf",
+    "application/x-pdf",
+    "application/acrobat",
+    "application/vnd.pdf",
+    "text/pdf",
+    "text/x-pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/msword"
+    );
 
     @Transactional
     public EditalResponseDTO create(MultipartFile file, EditalRequestDTO dto) {
@@ -37,8 +46,8 @@ public class EditalService {
             throw new FileSizeValidationException("File exceeds 10MB limit");
         }
 
-        if (!ALLOWED_TYPE.equals(file.getContentType())) {
-            throw new FileFormatValidationException("Only PDF files are allowed");
+        if (!ALLOWED_TYPES.contains(file.getContentType())) {
+            throw new FileFormatValidationException("Only PDF and DOCX files are allowed");
         }
 
         String fileUrl;

--- a/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
@@ -29,16 +29,16 @@ public class EditalService {
     private final OdsService odsService;
 
     private static final long MAX_FILE_SIZE = 10L * 1024 * 1024;
-    private static final Set<String> ALLOWED_TYPES = Set.of(
-    "application/pdf",
-    "application/x-pdf",
-    "application/acrobat",
-    "application/vnd.pdf",
-    "text/pdf",
-    "text/x-pdf",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/msword"
-    );
+    private static final Set<String> ALLOWED_TYPES =
+            Set.of(
+                    "application/pdf",
+                    "application/x-pdf",
+                    "application/acrobat",
+                    "application/vnd.pdf",
+                    "text/pdf",
+                    "text/x-pdf",
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "application/msword");
 
     @Transactional
     public EditalResponseDTO create(MultipartFile file, EditalRequestDTO dto) {
@@ -59,8 +59,7 @@ public class EditalService {
 
         Set<Ods> ods = Set.of();
         if (dto.odsIds() != null && !dto.odsIds().isEmpty()) {
-            List<String> odsStringIds =
-                    dto.odsIds().stream().map(String::valueOf).toList();
+            List<String> odsStringIds = dto.odsIds().stream().map(String::valueOf).toList();
             ods = odsService.resolveSelection(odsStringIds);
         }
 

--- a/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/EditalService.java
@@ -71,6 +71,7 @@ public class EditalService {
                 edital.getFileName(),
                 edital.getFileSize(),
                 edital.getMimeType(),
+                edital.getExpiredAt(),
                 edital.getCreatedAt(),
                 edital.getUpdatedAt());
     }

--- a/backend/src/main/resources/db/migration/V1.10__add_edital_ods.sql
+++ b/backend/src/main/resources/db/migration/V1.10__add_edital_ods.sql
@@ -1,0 +1,7 @@
+CREATE TABLE edital_ods (
+    edital_id BIGINT  NOT NULL,
+    ods_id    INTEGER NOT NULL,
+    PRIMARY KEY (edital_id, ods_id),
+    CONSTRAINT fk_edital_ods_edital FOREIGN KEY (edital_id) REFERENCES edital (id) ON DELETE CASCADE,
+    CONSTRAINT fk_edital_ods_ods    FOREIGN KEY (ods_id)    REFERENCES ods   (id) ON DELETE CASCADE
+);

--- a/backend/src/main/resources/db/migration/V1.9__alter_edital_table.sql
+++ b/backend/src/main/resources/db/migration/V1.9__alter_edital_table.sql
@@ -5,4 +5,5 @@ ALTER TABLE edital
     ALTER COLUMN file_url SET NOT NULL,
     ALTER COLUMN file_name SET NOT NULL,
     ALTER COLUMN file_size SET NOT NULL,
-    ALTER COLUMN mime_type SET NOT NULL;
+    ALTER COLUMN mime_type SET NOT NULL,
+    ADD COLUMN expired_at TIMESTAMP;

--- a/backend/src/main/resources/db/migration/V1.9__alter_edital_table.sql
+++ b/backend/src/main/resources/db/migration/V1.9__alter_edital_table.sql
@@ -6,5 +6,3 @@ ALTER TABLE edital
     ALTER COLUMN file_name SET NOT NULL,
     ALTER COLUMN file_size SET NOT NULL,
     ALTER COLUMN mime_type SET NOT NULL;
-
-CREATE INDEX idx_edital_deleted_at ON edital (deleted_at);

--- a/backend/src/main/resources/db/migration/V1.9__create_edital_table.sql
+++ b/backend/src/main/resources/db/migration/V1.9__create_edital_table.sql
@@ -1,0 +1,10 @@
+ALTER TABLE edital
+    ALTER COLUMN id TYPE BIGINT,
+    ALTER COLUMN file_size TYPE BIGINT,
+    ALTER COLUMN title SET NOT NULL,
+    ALTER COLUMN file_url SET NOT NULL,
+    ALTER COLUMN file_name SET NOT NULL,
+    ALTER COLUMN file_size SET NOT NULL,
+    ALTER COLUMN mime_type SET NOT NULL;
+
+CREATE INDEX idx_edital_deleted_at ON edital (deleted_at);

--- a/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
@@ -39,7 +39,8 @@ class EditalServiceTest {
 
         EditalRequestDTO dto = new EditalRequestDTO("Edital 2026", "Descrição do edital");
 
-        when(s3Uploader.uploadFile(any(MultipartFile.class), eq("editais"))).thenReturn("https://bucket.s3.amazonaws.com/editais/edital.pdf");
+        when(s3Uploader.uploadFile(any(MultipartFile.class), eq("editais")))
+                .thenReturn("https://bucket.s3.amazonaws.com/editais/edital.pdf");
 
         Edital saved = new Edital();
         saved.setId(1L);
@@ -84,7 +85,9 @@ class EditalServiceTest {
     void shouldThrowWhenFileTypeIsNotPdf() {
         MultipartFile file = mock(MultipartFile.class);
         when(file.getSize()).thenReturn(1024L);
-        when(file.getContentType()).thenReturn("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        when(file.getContentType())
+                .thenReturn(
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
 
         EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
 

--- a/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
@@ -1,0 +1,172 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.vinculohub.backend.dto.EditalRequestDTO;
+import com.vinculohub.backend.dto.EditalResponseDTO;
+import com.vinculohub.backend.exception.FileFormatValidationException;
+import com.vinculohub.backend.exception.FileSizeValidationException;
+import com.vinculohub.backend.model.Edital;
+import com.vinculohub.backend.repository.EditalRepository;
+import com.vinculohub.backend.service.storage.S3Uploader;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class EditalServiceTest {
+
+    @Mock private EditalRepository editalRepository;
+
+    @Mock private S3Uploader s3Uploader;
+
+    @InjectMocks private EditalService editalService;
+
+    @Test
+    void shouldCreateEditalSuccessfully() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn("application/pdf");
+        when(file.getOriginalFilename()).thenReturn("edital.pdf");
+
+        EditalRequestDTO dto = new EditalRequestDTO("Edital 2026", "Descrição do edital");
+
+        when(s3Uploader.uploadFile(any(MultipartFile.class), eq("editais"))).thenReturn("https://bucket.s3.amazonaws.com/editais/edital.pdf");
+
+        Edital saved = new Edital();
+        saved.setId(1L);
+        saved.setTitle("Edital 2026");
+        saved.setDescription("Descrição do edital");
+        saved.setFileUrl("https://bucket.s3.amazonaws.com/editais/edital.pdf");
+        saved.setFileName("edital.pdf");
+        saved.setFileSize(1024L);
+        saved.setMimeType("application/pdf");
+        saved.setCreatedAt(LocalDateTime.now());
+        saved.setUpdatedAt(LocalDateTime.now());
+
+        when(editalRepository.save(any(Edital.class))).thenReturn(saved);
+
+        EditalResponseDTO result = editalService.create(file, dto);
+
+        assertNotNull(result);
+        assertEquals(1L, result.id());
+        assertEquals("Edital 2026", result.title());
+        assertEquals("Descrição do edital", result.description());
+        assertEquals("https://bucket.s3.amazonaws.com/editais/edital.pdf", result.fileUrl());
+        assertEquals("application/pdf", result.mimeType());
+
+        verify(s3Uploader).uploadFile(file, "editais");
+        verify(editalRepository).save(any());
+    }
+
+    @Test
+    void shouldThrowWhenFileSizeExceedsLimit() {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(11 * 1024 * 1024L);
+
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+
+        assertThrows(FileSizeValidationException.class, () -> editalService.create(file, dto));
+
+        verifyNoInteractions(s3Uploader, editalRepository);
+    }
+
+    @Test
+    void shouldThrowWhenFileTypeIsNotPdf() {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn("application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+
+        assertThrows(FileFormatValidationException.class, () -> editalService.create(file, dto));
+
+        verifyNoInteractions(s3Uploader, editalRepository);
+    }
+
+    @Test
+    void shouldThrowRuntimeExceptionWhenS3UploadFails() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn("application/pdf");
+
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+
+        when(s3Uploader.uploadFile(any(), any())).thenThrow(IOException.class);
+
+        assertThrows(RuntimeException.class, () -> editalService.create(file, dto));
+
+        verifyNoInteractions(editalRepository);
+    }
+
+    @Test
+    void shouldReturnAllEditais() {
+        Edital e1 = buildEdital(1L, "Edital A");
+        Edital e2 = buildEdital(2L, "Edital B");
+
+        when(editalRepository.findAll()).thenReturn(List.of(e1, e2));
+
+        List<EditalResponseDTO> result = editalService.findAll();
+
+        assertEquals(2, result.size());
+        assertEquals("Edital A", result.get(0).title());
+        assertEquals("Edital B", result.get(1).title());
+    }
+
+    @Test
+    void shouldThrowFileFormatExceptionForNonPdfMimeType() {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn("image/jpeg");
+
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+
+        assertThrows(FileFormatValidationException.class, () -> editalService.create(file, dto));
+    }
+
+    @Test
+    void shouldNotThrowForPdfMimeType() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType()).thenReturn("application/pdf");
+        when(file.getOriginalFilename()).thenReturn("edital.pdf");
+
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+
+        when(s3Uploader.uploadFile(any(MultipartFile.class), any())).thenReturn("https://url");
+        when(editalRepository.save(any(Edital.class))).thenReturn(buildEdital(1L, "Edital"));
+
+        assertDoesNotThrow(() -> editalService.create(file, dto));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoEditaisExist() {
+        when(editalRepository.findAll()).thenReturn(List.of());
+
+        List<EditalResponseDTO> result = editalService.findAll();
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    private Edital buildEdital(Long id, String title) {
+        Edital edital = new Edital();
+        edital.setId(id);
+        edital.setTitle(title);
+        edital.setFileUrl("https://bucket.s3.amazonaws.com/editais/file.pdf");
+        edital.setFileName("file.pdf");
+        edital.setFileSize(2048L);
+        edital.setMimeType("application/pdf");
+        edital.setCreatedAt(LocalDateTime.now());
+        edital.setUpdatedAt(LocalDateTime.now());
+        return edital;
+    }
+}

--- a/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
@@ -84,18 +84,33 @@ class EditalServiceTest {
     }
 
     @Test
-    void shouldThrowWhenFileTypeIsNotPdf() {
+    void shouldThrowWhenFileTypeIsNotAllowed() {
         MultipartFile file = mock(MultipartFile.class);
         when(file.getSize()).thenReturn(1024L);
-        when(file.getContentType())
-                .thenReturn(
-                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        when(file.getContentType()).thenReturn("image/png");
 
         EditalRequestDTO dto = new EditalRequestDTO("Edital", null, null);
 
         assertThrows(FileFormatValidationException.class, () -> editalService.create(file, dto));
 
         verifyNoInteractions(s3Uploader, editalRepository);
+    }
+
+    @Test
+    void shouldNotThrowForDocxMimeType() throws Exception {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.getSize()).thenReturn(1024L);
+        when(file.getContentType())
+                .thenReturn(
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+        when(file.getOriginalFilename()).thenReturn("edital.docx");
+
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null, null);
+
+        when(s3Uploader.uploadFile(any(MultipartFile.class), any())).thenReturn("https://url");
+        when(editalRepository.save(any(Edital.class))).thenReturn(buildEdital(1L, "Edital"));
+
+        assertDoesNotThrow(() -> editalService.create(file, dto));
     }
 
     @Test

--- a/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
@@ -62,6 +62,7 @@ class EditalServiceTest {
         assertEquals("Descrição do edital", result.description());
         assertEquals("https://bucket.s3.amazonaws.com/editais/edital.pdf", result.fileUrl());
         assertEquals("application/pdf", result.mimeType());
+        assertNull(result.expiredAt());
 
         verify(s3Uploader).uploadFile(file, "editais");
         verify(editalRepository).save(any());

--- a/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/EditalServiceTest.java
@@ -28,6 +28,8 @@ class EditalServiceTest {
 
     @Mock private S3Uploader s3Uploader;
 
+    @Mock private OdsService odsService;
+
     @InjectMocks private EditalService editalService;
 
     @Test
@@ -37,7 +39,7 @@ class EditalServiceTest {
         when(file.getContentType()).thenReturn("application/pdf");
         when(file.getOriginalFilename()).thenReturn("edital.pdf");
 
-        EditalRequestDTO dto = new EditalRequestDTO("Edital 2026", "Descrição do edital");
+        EditalRequestDTO dto = new EditalRequestDTO("Edital 2026", "Descrição do edital", null);
 
         when(s3Uploader.uploadFile(any(MultipartFile.class), eq("editais")))
                 .thenReturn("https://bucket.s3.amazonaws.com/editais/edital.pdf");
@@ -74,7 +76,7 @@ class EditalServiceTest {
         MultipartFile file = mock(MultipartFile.class);
         when(file.getSize()).thenReturn(11 * 1024 * 1024L);
 
-        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null, null);
 
         assertThrows(FileSizeValidationException.class, () -> editalService.create(file, dto));
 
@@ -89,7 +91,7 @@ class EditalServiceTest {
                 .thenReturn(
                         "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
 
-        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null, null);
 
         assertThrows(FileFormatValidationException.class, () -> editalService.create(file, dto));
 
@@ -102,7 +104,7 @@ class EditalServiceTest {
         when(file.getSize()).thenReturn(1024L);
         when(file.getContentType()).thenReturn("application/pdf");
 
-        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null, null);
 
         when(s3Uploader.uploadFile(any(), any())).thenThrow(IOException.class);
 
@@ -131,7 +133,7 @@ class EditalServiceTest {
         when(file.getSize()).thenReturn(1024L);
         when(file.getContentType()).thenReturn("image/jpeg");
 
-        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null, null);
 
         assertThrows(FileFormatValidationException.class, () -> editalService.create(file, dto));
     }
@@ -143,7 +145,7 @@ class EditalServiceTest {
         when(file.getContentType()).thenReturn("application/pdf");
         when(file.getOriginalFilename()).thenReturn("edital.pdf");
 
-        EditalRequestDTO dto = new EditalRequestDTO("Edital", null);
+        EditalRequestDTO dto = new EditalRequestDTO("Edital", null, null);
 
         when(s3Uploader.uploadFile(any(MultipartFile.class), any())).thenReturn("https://url");
         when(editalRepository.save(any(Edital.class))).thenReturn(buildEdital(1L, "Edital"));

--- a/docs/db/vinculo_hub.dbml
+++ b/docs/db/vinculo_hub.dbml
@@ -152,6 +152,7 @@ Table edital {
   file_name varchar(255)
   file_size integer
   mime_type varchar(100)
+  expired_at timestamp
   created_at timestamp
   updated_at timestamp
   deleted_at timestamp


### PR DESCRIPTION
Add full CRUD backend for editais: JPA entity, DTOs, repository, service with S3 upload (PDF only, 10MB limit), and REST endpoints. POST requires ADMIN role; GET /api/editais is public.

## Issue Link
Closes #209 

## Description
## Task Notes
## Screenshots
<img width="1642" height="764" alt="image" src="https://github.com/user-attachments/assets/63447d34-6c6a-49ec-a180-e1ecf7cddfcf" />