### PR TITLE
feat(projects): implementar atualizacao de projeto da ONG

### DIFF
--- a/backend/src/main/java/com/vinculohub/backend/controller/ProjectController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/ProjectController.java
@@ -7,6 +7,7 @@ import com.vinculohub.backend.dto.ProjectCreateResponse;
 import com.vinculohub.backend.dto.ProjectDetailResponse;
 import com.vinculohub.backend.dto.ProjectFilterParams;
 import com.vinculohub.backend.dto.ProjectListItemDTO;
+import com.vinculohub.backend.dto.ProjectUpdateRequest;
 import com.vinculohub.backend.model.Project;
 import com.vinculohub.backend.model.enums.ProjectStatus;
 import com.vinculohub.backend.model.enums.ProjectType;
@@ -26,6 +27,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -80,6 +82,18 @@ public class ProjectController {
         log.info("GET /api/projects/{}", id);
         Project project = projectService.findById(id);
         return ResponseEntity.ok(toResponse(project));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('NPO')")
+    public ResponseEntity<ProjectDetailResponse> updateProject(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody ProjectUpdateRequest request,
+            @PathVariable Long id) {
+        log.info("PUT /api/projects/{} | sub={} title={}", id, jwt.getSubject(), request.title());
+        Project updated = projectService.updateProject(jwt.getSubject(), id, request);
+        log.info("Project updated | id={} npoId={}", updated.getId(), updated.getNpo().getId());
+        return ResponseEntity.ok(toResponse(updated));
     }
 
     private static ProjectDetailResponse toResponse(Project project) {

--- a/backend/src/main/java/com/vinculohub/backend/dto/ProjectUpdateRequest.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/ProjectUpdateRequest.java
@@ -1,0 +1,32 @@
+/* (C)2026 */
+package com.vinculohub.backend.dto;
+
+import com.vinculohub.backend.model.enums.ProjectType;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+public record ProjectUpdateRequest(
+        @NotBlank(message = "Título é obrigatório")
+                @Size(max = 255, message = "Título deve ter no máximo 255 caracteres")
+                String title,
+        @NotBlank(message = "Resumo é obrigatório")
+                @Size(min = 50, max = 500, message = "Resumo deve ter entre 50 e 500 caracteres")
+                String description,
+        @DecimalMin(value = "0.00", message = "Valor necessário não pode ser negativo")
+                BigDecimal budgetNeeded,
+        LocalDate startDate,
+        LocalDate endDate,
+        @NotEmpty(message = "ODS é obrigatório") List<Integer> odsIds,
+        @NotNull(message = "Tipo de projeto é obrigatório") ProjectType type,
+        String focusArea,
+        String fundraisingDeadline,
+        Integer beneficiariesCount,
+        String location,
+        @Size(max = 600, message = "Objetivo principal deve ter no máximo 600 caracteres")
+                String mainObjective) {}

--- a/backend/src/main/java/com/vinculohub/backend/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/vinculohub/backend/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+/* (C)2026 */
+package com.vinculohub.backend.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+
+    public ForbiddenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/vinculohub/backend/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -102,6 +103,17 @@ public class GlobalExceptionHandler {
         log.warn("400 Type mismatch: {}", message);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), message));
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAuthorizationDenied(
+            AuthorizationDeniedException ex) {
+        log.warn("403 Forbidden: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(
+                        new ErrorResponse(
+                                HttpStatus.FORBIDDEN.value(),
+                                "Você não tem permissão para realizar esta ação."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/vinculohub/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/vinculohub/backend/exception/GlobalExceptionHandler.java
@@ -47,6 +47,13 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
     }
 
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> handleForbidden(ForbiddenException ex) {
+        log.warn("403 Forbidden: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(HttpStatus.FORBIDDEN.value(), ex.getMessage()));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
         log.warn("400 Illegal Argument: {}", ex.getMessage());

--- a/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
@@ -7,7 +7,9 @@ import com.vinculohub.backend.dto.ProjectCreateRequest;
 import com.vinculohub.backend.dto.ProjectCreateResponse;
 import com.vinculohub.backend.dto.ProjectFilterParams;
 import com.vinculohub.backend.dto.ProjectListItemDTO;
+import com.vinculohub.backend.dto.ProjectUpdateRequest;
 import com.vinculohub.backend.exception.BadRequestException;
+import com.vinculohub.backend.exception.ForbiddenException;
 import com.vinculohub.backend.exception.NotFoundException;
 import com.vinculohub.backend.exception.UserNotFoundException;
 import com.vinculohub.backend.model.Npo;
@@ -69,6 +71,67 @@ public class ProjectService {
                         .build();
 
         return save(project);
+    }
+
+    @Transactional
+    public Project updateProject(String auth0Id, Long projectId, ProjectUpdateRequest request) {
+        if (auth0Id == null || auth0Id.isBlank()) {
+            log.error("Usuário autenticado não identificado");
+            throw new BadRequestException("Não foi possível identificar o usuário autenticado.");
+        }
+
+        if (request == null) {
+            throw new BadRequestException("Dados do projeto são obrigatórios.");
+        }
+
+        log.info("Updating project | projectId={} auth0Id={}", projectId, auth0Id);
+
+        User user = userRepository.findByAuth0Id(auth0Id).orElseThrow(UserNotFoundException::new);
+        Npo npo =
+                npoRepository
+                        .findByUserId(user.getId())
+                        .orElseThrow(() -> new NotFoundException("ONG não encontrada"));
+
+        Project project = projectRepository
+                .findById(projectId)
+                .orElseThrow(() -> new NotFoundException("Projeto não encontrado."));
+
+        if (!project.getNpo().getId().equals(npo.getId())) {
+            log.warn("Access denied: ONG {} tried to update project {} of ONG {}", 
+                npo.getId(), projectId, project.getNpo().getId());
+            throw new ForbiddenException("Você não tem permissão para atualizar este projeto.");
+        }
+
+        Set<Ods> ods;
+        try {
+            List<String> odsIds =
+                    request.odsIds() == null
+                            ? null
+                            : request.odsIds().stream()
+                                    .map(odsId -> String.valueOf(odsId))
+                                    .toList();
+            ods = odsService.resolveSelection(odsIds);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("ODS inválido");
+        }
+
+        project.setTitle(request.title());
+        project.setDescription(request.description());
+        project.setBudgetNeeded(request.budgetNeeded());
+        project.setType(request.type());
+        project.setStartDate(request.startDate());
+        project.setEndDate(request.endDate());
+        project.setOds(ods);
+        project.setFocusArea(request.focusArea());
+        project.setFundraisingDeadline(request.fundraisingDeadline());
+        project.setBeneficiariesCount(request.beneficiariesCount());
+        project.setLocation(request.location());
+        project.setMainObjective(request.mainObjective());
+
+        Project updated = projectRepository.save(project);
+        log.info("Project updated | id={} npoId={}", updated.getId(), npo.getId());
+
+        return updated;
     }
 
     @Transactional

--- a/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
@@ -92,9 +92,10 @@ public class ProjectService {
                         .findByUserId(user.getId())
                         .orElseThrow(() -> new NotFoundException("ONG não encontrada"));
 
-        Project project = projectRepository
-                .findById(projectId)
-                .orElseThrow(() -> new NotFoundException("Projeto não encontrado."));
+        Project project =
+                projectRepository
+                        .findById(projectId)
+                        .orElseThrow(() -> new NotFoundException("Projeto não encontrado."));
 
         if (!project.getNpo().getId().equals(npo.getId())) {
             log.warn(

--- a/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/ProjectService.java
@@ -97,8 +97,11 @@ public class ProjectService {
                 .orElseThrow(() -> new NotFoundException("Projeto não encontrado."));
 
         if (!project.getNpo().getId().equals(npo.getId())) {
-            log.warn("Access denied: ONG {} tried to update project {} of ONG {}", 
-                npo.getId(), projectId, project.getNpo().getId());
+            log.warn(
+                    "Access denied: ONG {} tried to update project {} of ONG {}",
+                    npo.getId(),
+                    projectId,
+                    project.getNpo().getId());
             throw new ForbiddenException("Você não tem permissão para atualizar este projeto.");
         }
 

--- a/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
@@ -3,6 +3,7 @@ package com.vinculohub.backend.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -10,18 +11,23 @@ import com.vinculohub.backend.database.AbstractIntegrationTest;
 import com.vinculohub.backend.model.Npo;
 import com.vinculohub.backend.model.Ods;
 import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.model.User;
 import com.vinculohub.backend.model.enums.NpoSize;
 import com.vinculohub.backend.model.enums.ProjectStatus;
 import com.vinculohub.backend.model.enums.ProjectType;
 import com.vinculohub.backend.repository.NpoRepository;
 import com.vinculohub.backend.repository.OdsRepository;
 import com.vinculohub.backend.repository.ProjectRepository;
+import com.vinculohub.backend.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,6 +39,8 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @Autowired private ProjectRepository projectRepository;
     @Autowired private NpoRepository npoRepository;
     @Autowired private OdsRepository odsRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private ObjectMapper objectMapper;
 
     private Npo npo;
     private Ods ods1;
@@ -363,5 +371,219 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @DisplayName("GET /api/projects sem autenticação retorna 401")
     void shouldReturn401WithoutAuth() throws Exception {
         mockMvc.perform(get("/api/projects")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("PUT /api/projects/{id} com sucesso retorna 200 com projeto atualizado")
+    void shouldUpdateProjectSuccessfully() throws Exception {
+        User user = userRepository.save(
+                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        Npo ownerNpo = npoRepository.save(
+                Npo.builder()
+                        .name("ONG Proprietária")
+                        .npoSize(NpoSize.small)
+                        .userId(user.getId())
+                        .build());
+        Project project = projectRepository.save(
+                Project.builder()
+                        .npo(ownerNpo)
+                        .title("Título Original")
+                        .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                        .status(ProjectStatus.ACTIVE)
+                        .type(ProjectType.SOCIAL)
+                        .budgetNeeded(BigDecimal.valueOf(1000))
+                        .ods(Set.of(ods1))
+                        .build());
+
+        String updateRequestJson = objectMapper.writeValueAsString(
+                java.util.Map.of(
+                        "title", "Título Atualizado",
+                        "description", "Descrição atualizada com pelo menos cinquenta caracteres válidos e completos.",
+                        "budgetNeeded", 2000,
+                        "type", "CULTURAL",
+                        "odsIds", java.util.List.of(1, 3)));
+
+        mockMvc.perform(
+                        put("/api/projects/" + project.getId())
+                                .with(jwt()
+                                        .jwt(jwt -> jwt.subject("auth0|npo_owner"))
+                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(updateRequestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Título Atualizado"))
+                .andExpect(jsonPath("$.type").value("CULTURAL"))
+                .andExpect(jsonPath("$.budgetNeeded").value(2000));
+    }
+
+    @Test
+    @DisplayName("PUT /api/projects/{id} com campos inválidos retorna 400")
+    void shouldReturn400WhenUpdatingWithInvalidFields() throws Exception {
+        User user = userRepository.save(
+                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        Npo ownerNpo = npoRepository.save(
+                Npo.builder()
+                        .name("ONG Proprietária")
+                        .npoSize(NpoSize.small)
+                        .userId(user.getId())
+                        .build());
+        Project project = projectRepository.save(
+                Project.builder()
+                        .npo(ownerNpo)
+                        .title("Título Original")
+                        .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                        .status(ProjectStatus.ACTIVE)
+                        .type(ProjectType.SOCIAL)
+                        .budgetNeeded(BigDecimal.valueOf(1000))
+                        .ods(Set.of(ods1))
+                        .build());
+
+        String updateRequestJson = objectMapper.writeValueAsString(
+                java.util.Map.of(
+                        "title", "Ti",
+                        "description", "Curta",
+                        "budgetNeeded", -1000,
+                        "type", "CULTURAL",
+                        "odsIds", java.util.List.of()));
+
+        mockMvc.perform(
+                        put("/api/projects/" + project.getId())
+                                .with(jwt()
+                                        .jwt(jwt -> jwt.subject("auth0|npo_owner"))
+                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(updateRequestJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    @DisplayName("PUT /api/projects/{id} inexistente retorna 404")
+    void shouldReturn404WhenUpdatingNonExistentProject() throws Exception {
+        User user = userRepository.save(
+                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        npoRepository.save(
+                Npo.builder()
+                        .name("ONG Proprietária")
+                        .npoSize(NpoSize.small)
+                        .userId(user.getId())
+                        .build());
+
+        String updateRequestJson = objectMapper.writeValueAsString(
+                java.util.Map.of(
+                        "title", "Título Novo",
+                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                        "budgetNeeded", 2000,
+                        "type", "CULTURAL",
+                        "odsIds", java.util.List.of(1)));
+
+        mockMvc.perform(
+                        put("/api/projects/99999")
+                                .with(jwt()
+                                        .jwt(jwt -> jwt.subject("auth0|npo_owner"))
+                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(updateRequestJson))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    @Test
+    @DisplayName("PUT /api/projects/{id} por ONG não proprietária retorna 403")
+    void shouldReturn403WhenNpoIsNotOwner() throws Exception {
+        User ownerUser = userRepository.save(
+                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        User otherUser = userRepository.save(
+                User.builder().auth0Id("auth0|other_npo").name("Other NPO").build());
+        
+        Npo ownerNpo = npoRepository.save(
+                Npo.builder()
+                        .name("ONG Proprietária")
+                        .npoSize(NpoSize.small)
+                        .userId(ownerUser.getId())
+                        .build());
+        Npo otherNpo = npoRepository.save(
+                Npo.builder()
+                        .name("Outra ONG")
+                        .npoSize(NpoSize.small)
+                        .userId(otherUser.getId())
+                        .build());
+        
+        Project project = projectRepository.save(
+                Project.builder()
+                        .npo(ownerNpo)
+                        .title("Projeto da ONG Proprietária")
+                        .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                        .status(ProjectStatus.ACTIVE)
+                        .type(ProjectType.SOCIAL)
+                        .budgetNeeded(BigDecimal.valueOf(1000))
+                        .ods(Set.of(ods1))
+                        .build());
+
+        String updateRequestJson = objectMapper.writeValueAsString(
+                java.util.Map.of(
+                        "title", "Título Novo",
+                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                        "budgetNeeded", 2000,
+                        "type", "CULTURAL",
+                        "odsIds", java.util.List.of(1)));
+
+        mockMvc.perform(
+                        put("/api/projects/" + project.getId())
+                                .with(jwt()
+                                        .jwt(jwt -> jwt.subject("auth0|other_npo"))
+                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(updateRequestJson))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403));
+    }
+
+    @Test
+    @DisplayName("PUT /api/projects/{id} sem autenticação retorna 401")
+    void shouldReturn401WhenUpdatingWithoutAuth() throws Exception {
+        String updateRequestJson = objectMapper.writeValueAsString(
+                java.util.Map.of(
+                        "title", "Título Novo",
+                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                        "budgetNeeded", 2000,
+                        "type", "CULTURAL",
+                        "odsIds", java.util.List.of(1)));
+
+        mockMvc.perform(
+                        put("/api/projects/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(updateRequestJson))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("PUT /api/projects/{id} com papel ROLE_COMPANY retorna 403")
+    void shouldReturn403WhenUpdatingWithWrongRole() throws Exception {
+        User user = userRepository.save(
+                User.builder().auth0Id("auth0|company").name("Company User").build());
+        npoRepository.save(
+                Npo.builder()
+                        .name("ONG Teste")
+                        .npoSize(NpoSize.small)
+                        .userId(user.getId())
+                        .build());
+
+        String updateRequestJson = objectMapper.writeValueAsString(
+                java.util.Map.of(
+                        "title", "Título Novo",
+                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                        "budgetNeeded", 2000,
+                        "type", "CULTURAL",
+                        "odsIds", java.util.List.of(1)));
+
+        mockMvc.perform(
+                        put("/api/projects/1")
+                                .with(jwt()
+                                        .jwt(jwt -> jwt.subject("auth0|company"))
+                                        .authorities(new SimpleGrantedAuthority("ROLE_COMPANY")))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(updateRequestJson))
+                .andExpect(status().isForbidden());
     }
 }

--- a/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
@@ -51,6 +51,7 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     void setup() {
         projectRepository.deleteAll();
         npoRepository.deleteAll();
+        userRepository.deleteAll();
         npo =
                 npoRepository.save(
                         Npo.builder()

--- a/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
@@ -376,32 +376,40 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PUT /api/projects/{id} com sucesso retorna 200 com projeto atualizado")
     void shouldUpdateProjectSuccessfully() throws Exception {
-        User user = userRepository.save(
-                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
-        Npo ownerNpo = npoRepository.save(
-                Npo.builder()
-                        .name("ONG Proprietária")
-                        .npoSize(NpoSize.small)
-                        .userId(user.getId())
-                        .build());
-        Project project = projectRepository.save(
-                Project.builder()
-                        .npo(ownerNpo)
-                        .title("Título Original")
-                        .description("Descrição original com pelo menos cinquenta caracteres válidos.")
-                        .status(ProjectStatus.ACTIVE)
-                        .type(ProjectType.SOCIAL)
-                        .budgetNeeded(BigDecimal.valueOf(1000))
-                        .ods(Set.of(ods1))
-                        .build());
+        User user =
+                userRepository.save(
+                        User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        Npo ownerNpo =
+                npoRepository.save(
+                        Npo.builder()
+                                .name("ONG Proprietária")
+                                .npoSize(NpoSize.small)
+                                .userId(user.getId())
+                                .build());
+        Project project =
+                projectRepository.save(
+                        Project.builder()
+                                .npo(ownerNpo)
+                                .title("Título Original")
+                                .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                                .status(ProjectStatus.ACTIVE)
+                                .type(ProjectType.SOCIAL)
+                                .budgetNeeded(BigDecimal.valueOf(1000))
+                                .ods(Set.of(ods1))
+                                .build());
 
-        String updateRequestJson = objectMapper.writeValueAsString(
-                java.util.Map.of(
-                        "title", "Título Atualizado",
-                        "description", "Descrição atualizada com pelo menos cinquenta caracteres válidos e completos.",
-                        "budgetNeeded", 2000,
-                        "type", "CULTURAL",
-                        "odsIds", java.util.List.of(1, 3)));
+        String updateRequestJson =
+                objectMapper.writeValueAsString(
+                        java.util.Map.of(
+                                "title", "Título Atualizado",
+                                "description",
+                                "Descrição atualizada com pelo menos cinquenta caracteres válidos e completos.",
+                                "budgetNeeded",
+                                2000,
+                                "type",
+                                "CULTURAL",
+                                "odsIds",
+                                java.util.List.of(1, 3)));
 
         mockMvc.perform(
                         put("/api/projects/" + project.getId())
@@ -419,32 +427,39 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PUT /api/projects/{id} com campos inválidos retorna 400")
     void shouldReturn400WhenUpdatingWithInvalidFields() throws Exception {
-        User user = userRepository.save(
-                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
-        Npo ownerNpo = npoRepository.save(
-                Npo.builder()
-                        .name("ONG Proprietária")
-                        .npoSize(NpoSize.small)
-                        .userId(user.getId())
-                        .build());
-        Project project = projectRepository.save(
-                Project.builder()
-                        .npo(ownerNpo)
-                        .title("Título Original")
-                        .description("Descrição original com pelo menos cinquenta caracteres válidos.")
-                        .status(ProjectStatus.ACTIVE)
-                        .type(ProjectType.SOCIAL)
-                        .budgetNeeded(BigDecimal.valueOf(1000))
-                        .ods(Set.of(ods1))
-                        .build());
+        User user =
+                userRepository.save(
+                        User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        Npo ownerNpo =
+                npoRepository.save(
+                        Npo.builder()
+                                .name("ONG Proprietária")
+                                .npoSize(NpoSize.small)
+                                .userId(user.getId())
+                                .build());
+        Project project =
+                projectRepository.save(
+                        Project.builder()
+                                .npo(ownerNpo)
+                                .title("Título Original")
+                                .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                                .status(ProjectStatus.ACTIVE)
+                                .type(ProjectType.SOCIAL)
+                                .budgetNeeded(BigDecimal.valueOf(1000))
+                                .ods(Set.of(ods1))
+                                .build());
 
-        String updateRequestJson = objectMapper.writeValueAsString(
-                java.util.Map.of(
-                        "title", "Ti",
-                        "description", "Curta",
-                        "budgetNeeded", -1000,
-                        "type", "CULTURAL",
-                        "odsIds", java.util.List.of()));
+        String updateRequestJson =
+                objectMapper.writeValueAsString(
+                        java.util.Map.of(
+                                "title", "Ti",
+                                "description", "Curta",
+                                "budgetNeeded",
+                                -1000,
+                                "type",
+                                "CULTURAL",
+                                "odsIds",
+                                java.util.List.of()));
 
         mockMvc.perform(
                         put("/api/projects/" + project.getId())
@@ -460,8 +475,9 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PUT /api/projects/{id} inexistente retorna 404")
     void shouldReturn404WhenUpdatingNonExistentProject() throws Exception {
-        User user = userRepository.save(
-                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        User user =
+                userRepository.save(
+                        User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
         npoRepository.save(
                 Npo.builder()
                         .name("ONG Proprietária")
@@ -469,13 +485,18 @@ class ProjectControllerTest extends AbstractIntegrationTest {
                         .userId(user.getId())
                         .build());
 
-        String updateRequestJson = objectMapper.writeValueAsString(
-                java.util.Map.of(
-                        "title", "Título Novo",
-                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
-                        "budgetNeeded", 2000,
-                        "type", "CULTURAL",
-                        "odsIds", java.util.List.of(1)));
+        String updateRequestJson =
+                objectMapper.writeValueAsString(
+                        java.util.Map.of(
+                                "title", "Título Novo",
+                                "description",
+                                "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                                "budgetNeeded",
+                                2000,
+                                "type",
+                                "CULTURAL",
+                                "odsIds",
+                                java.util.List.of(1)));
 
         mockMvc.perform(
                         put("/api/projects/99999")
@@ -491,42 +512,52 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PUT /api/projects/{id} por ONG não proprietária retorna 403")
     void shouldReturn403WhenNpoIsNotOwner() throws Exception {
-        User ownerUser = userRepository.save(
-                User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
-        User otherUser = userRepository.save(
-                User.builder().auth0Id("auth0|other_npo").name("Other NPO").build());
-        
-        Npo ownerNpo = npoRepository.save(
-                Npo.builder()
-                        .name("ONG Proprietária")
-                        .npoSize(NpoSize.small)
-                        .userId(ownerUser.getId())
-                        .build());
-        Npo otherNpo = npoRepository.save(
-                Npo.builder()
-                        .name("Outra ONG")
-                        .npoSize(NpoSize.small)
-                        .userId(otherUser.getId())
-                        .build());
-        
-        Project project = projectRepository.save(
-                Project.builder()
-                        .npo(ownerNpo)
-                        .title("Projeto da ONG Proprietária")
-                        .description("Descrição original com pelo menos cinquenta caracteres válidos.")
-                        .status(ProjectStatus.ACTIVE)
-                        .type(ProjectType.SOCIAL)
-                        .budgetNeeded(BigDecimal.valueOf(1000))
-                        .ods(Set.of(ods1))
-                        .build());
+        User ownerUser =
+                userRepository.save(
+                        User.builder().auth0Id("auth0|npo_owner").name("NPO Owner").build());
+        User otherUser =
+                userRepository.save(
+                        User.builder().auth0Id("auth0|other_npo").name("Other NPO").build());
 
-        String updateRequestJson = objectMapper.writeValueAsString(
-                java.util.Map.of(
-                        "title", "Título Novo",
-                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
-                        "budgetNeeded", 2000,
-                        "type", "CULTURAL",
-                        "odsIds", java.util.List.of(1)));
+        Npo ownerNpo =
+                npoRepository.save(
+                        Npo.builder()
+                                .name("ONG Proprietária")
+                                .npoSize(NpoSize.small)
+                                .userId(ownerUser.getId())
+                                .build());
+        Npo otherNpo =
+                npoRepository.save(
+                        Npo.builder()
+                                .name("Outra ONG")
+                                .npoSize(NpoSize.small)
+                                .userId(otherUser.getId())
+                                .build());
+
+        Project project =
+                projectRepository.save(
+                        Project.builder()
+                                .npo(ownerNpo)
+                                .title("Projeto da ONG Proprietária")
+                                .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                                .status(ProjectStatus.ACTIVE)
+                                .type(ProjectType.SOCIAL)
+                                .budgetNeeded(BigDecimal.valueOf(1000))
+                                .ods(Set.of(ods1))
+                                .build());
+
+        String updateRequestJson =
+                objectMapper.writeValueAsString(
+                        java.util.Map.of(
+                                "title", "Título Novo",
+                                "description",
+                                "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                                "budgetNeeded",
+                                2000,
+                                "type",
+                                "CULTURAL",
+                                "odsIds",
+                                java.util.List.of(1)));
 
         mockMvc.perform(
                         put("/api/projects/" + project.getId())
@@ -542,13 +573,18 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PUT /api/projects/{id} sem autenticação retorna 401")
     void shouldReturn401WhenUpdatingWithoutAuth() throws Exception {
-        String updateRequestJson = objectMapper.writeValueAsString(
-                java.util.Map.of(
-                        "title", "Título Novo",
-                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
-                        "budgetNeeded", 2000,
-                        "type", "CULTURAL",
-                        "odsIds", java.util.List.of(1)));
+        String updateRequestJson =
+                objectMapper.writeValueAsString(
+                        java.util.Map.of(
+                                "title", "Título Novo",
+                                "description",
+                                "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                                "budgetNeeded",
+                                2000,
+                                "type",
+                                "CULTURAL",
+                                "odsIds",
+                                java.util.List.of(1)));
 
         mockMvc.perform(
                         put("/api/projects/1")
@@ -560,8 +596,9 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("PUT /api/projects/{id} com papel ROLE_COMPANY retorna 403")
     void shouldReturn403WhenUpdatingWithWrongRole() throws Exception {
-        User user = userRepository.save(
-                User.builder().auth0Id("auth0|company").name("Company User").build());
+        User user =
+                userRepository.save(
+                        User.builder().auth0Id("auth0|company").name("Company User").build());
         npoRepository.save(
                 Npo.builder()
                         .name("ONG Teste")
@@ -569,13 +606,18 @@ class ProjectControllerTest extends AbstractIntegrationTest {
                         .userId(user.getId())
                         .build());
 
-        String updateRequestJson = objectMapper.writeValueAsString(
-                java.util.Map.of(
-                        "title", "Título Novo",
-                        "description", "Descrição nova com pelo menos cinquenta caracteres válidos.",
-                        "budgetNeeded", 2000,
-                        "type", "CULTURAL",
-                        "odsIds", java.util.List.of(1)));
+        String updateRequestJson =
+                objectMapper.writeValueAsString(
+                        java.util.Map.of(
+                                "title", "Título Novo",
+                                "description",
+                                "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                                "budgetNeeded",
+                                2000,
+                                "type",
+                                "CULTURAL",
+                                "odsIds",
+                                java.util.List.of(1)));
 
         mockMvc.perform(
                         put("/api/projects/1")

--- a/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vinculohub.backend.database.AbstractIntegrationTest;
 import com.vinculohub.backend.model.Npo;
 import com.vinculohub.backend.model.Ods;
@@ -19,7 +20,6 @@ import com.vinculohub.backend.repository.NpoRepository;
 import com.vinculohub.backend.repository.OdsRepository;
 import com.vinculohub.backend.repository.ProjectRepository;
 import com.vinculohub.backend.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
@@ -391,7 +391,9 @@ class ProjectControllerTest extends AbstractIntegrationTest {
                         Project.builder()
                                 .npo(ownerNpo)
                                 .title("Título Original")
-                                .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                                .description(
+                                        "Descrição original com pelo menos cinquenta caracteres"
+                                                + " válidos.")
                                 .status(ProjectStatus.ACTIVE)
                                 .type(ProjectType.SOCIAL)
                                 .budgetNeeded(BigDecimal.valueOf(1000))
@@ -401,9 +403,11 @@ class ProjectControllerTest extends AbstractIntegrationTest {
         String updateRequestJson =
                 objectMapper.writeValueAsString(
                         java.util.Map.of(
-                                "title", "Título Atualizado",
+                                "title",
+                                "Título Atualizado",
                                 "description",
-                                "Descrição atualizada com pelo menos cinquenta caracteres válidos e completos.",
+                                "Descrição atualizada com pelo menos cinquenta caracteres válidos e"
+                                        + " completos.",
                                 "budgetNeeded",
                                 2000,
                                 "type",
@@ -413,9 +417,10 @@ class ProjectControllerTest extends AbstractIntegrationTest {
 
         mockMvc.perform(
                         put("/api/projects/" + project.getId())
-                                .with(jwt()
-                                        .jwt(jwt -> jwt.subject("auth0|npo_owner"))
-                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .with(
+                                        jwt().jwt(jwt -> jwt.subject("auth0|npo_owner"))
+                                                .authorities(
+                                                        new SimpleGrantedAuthority("ROLE_NPO")))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(updateRequestJson))
                 .andExpect(status().isOk())
@@ -442,7 +447,9 @@ class ProjectControllerTest extends AbstractIntegrationTest {
                         Project.builder()
                                 .npo(ownerNpo)
                                 .title("Título Original")
-                                .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                                .description(
+                                        "Descrição original com pelo menos cinquenta caracteres"
+                                                + " válidos.")
                                 .status(ProjectStatus.ACTIVE)
                                 .type(ProjectType.SOCIAL)
                                 .budgetNeeded(BigDecimal.valueOf(1000))
@@ -452,8 +459,10 @@ class ProjectControllerTest extends AbstractIntegrationTest {
         String updateRequestJson =
                 objectMapper.writeValueAsString(
                         java.util.Map.of(
-                                "title", "Ti",
-                                "description", "Curta",
+                                "title",
+                                "Ti",
+                                "description",
+                                "Curta",
                                 "budgetNeeded",
                                 -1000,
                                 "type",
@@ -463,9 +472,10 @@ class ProjectControllerTest extends AbstractIntegrationTest {
 
         mockMvc.perform(
                         put("/api/projects/" + project.getId())
-                                .with(jwt()
-                                        .jwt(jwt -> jwt.subject("auth0|npo_owner"))
-                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .with(
+                                        jwt().jwt(jwt -> jwt.subject("auth0|npo_owner"))
+                                                .authorities(
+                                                        new SimpleGrantedAuthority("ROLE_NPO")))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(updateRequestJson))
                 .andExpect(status().isBadRequest())
@@ -488,7 +498,8 @@ class ProjectControllerTest extends AbstractIntegrationTest {
         String updateRequestJson =
                 objectMapper.writeValueAsString(
                         java.util.Map.of(
-                                "title", "Título Novo",
+                                "title",
+                                "Título Novo",
                                 "description",
                                 "Descrição nova com pelo menos cinquenta caracteres válidos.",
                                 "budgetNeeded",
@@ -500,9 +511,10 @@ class ProjectControllerTest extends AbstractIntegrationTest {
 
         mockMvc.perform(
                         put("/api/projects/99999")
-                                .with(jwt()
-                                        .jwt(jwt -> jwt.subject("auth0|npo_owner"))
-                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .with(
+                                        jwt().jwt(jwt -> jwt.subject("auth0|npo_owner"))
+                                                .authorities(
+                                                        new SimpleGrantedAuthority("ROLE_NPO")))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(updateRequestJson))
                 .andExpect(status().isNotFound())
@@ -539,7 +551,9 @@ class ProjectControllerTest extends AbstractIntegrationTest {
                         Project.builder()
                                 .npo(ownerNpo)
                                 .title("Projeto da ONG Proprietária")
-                                .description("Descrição original com pelo menos cinquenta caracteres válidos.")
+                                .description(
+                                        "Descrição original com pelo menos cinquenta caracteres"
+                                                + " válidos.")
                                 .status(ProjectStatus.ACTIVE)
                                 .type(ProjectType.SOCIAL)
                                 .budgetNeeded(BigDecimal.valueOf(1000))
@@ -549,7 +563,8 @@ class ProjectControllerTest extends AbstractIntegrationTest {
         String updateRequestJson =
                 objectMapper.writeValueAsString(
                         java.util.Map.of(
-                                "title", "Título Novo",
+                                "title",
+                                "Título Novo",
                                 "description",
                                 "Descrição nova com pelo menos cinquenta caracteres válidos.",
                                 "budgetNeeded",
@@ -561,9 +576,10 @@ class ProjectControllerTest extends AbstractIntegrationTest {
 
         mockMvc.perform(
                         put("/api/projects/" + project.getId())
-                                .with(jwt()
-                                        .jwt(jwt -> jwt.subject("auth0|other_npo"))
-                                        .authorities(new SimpleGrantedAuthority("ROLE_NPO")))
+                                .with(
+                                        jwt().jwt(jwt -> jwt.subject("auth0|other_npo"))
+                                                .authorities(
+                                                        new SimpleGrantedAuthority("ROLE_NPO")))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(updateRequestJson))
                 .andExpect(status().isForbidden())
@@ -576,7 +592,8 @@ class ProjectControllerTest extends AbstractIntegrationTest {
         String updateRequestJson =
                 objectMapper.writeValueAsString(
                         java.util.Map.of(
-                                "title", "Título Novo",
+                                "title",
+                                "Título Novo",
                                 "description",
                                 "Descrição nova com pelo menos cinquenta caracteres válidos.",
                                 "budgetNeeded",
@@ -609,7 +626,8 @@ class ProjectControllerTest extends AbstractIntegrationTest {
         String updateRequestJson =
                 objectMapper.writeValueAsString(
                         java.util.Map.of(
-                                "title", "Título Novo",
+                                "title",
+                                "Título Novo",
                                 "description",
                                 "Descrição nova com pelo menos cinquenta caracteres válidos.",
                                 "budgetNeeded",
@@ -621,9 +639,10 @@ class ProjectControllerTest extends AbstractIntegrationTest {
 
         mockMvc.perform(
                         put("/api/projects/1")
-                                .with(jwt()
-                                        .jwt(jwt -> jwt.subject("auth0|company"))
-                                        .authorities(new SimpleGrantedAuthority("ROLE_COMPANY")))
+                                .with(
+                                        jwt().jwt(jwt -> jwt.subject("auth0|company"))
+                                                .authorities(
+                                                        new SimpleGrantedAuthority("ROLE_COMPANY")))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(updateRequestJson))
                 .andExpect(status().isForbidden());

--- a/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,7 +17,9 @@ import com.vinculohub.backend.dto.ProjectCreateRequest;
 import com.vinculohub.backend.dto.ProjectCreateResponse;
 import com.vinculohub.backend.dto.ProjectFilterParams;
 import com.vinculohub.backend.dto.ProjectListItemDTO;
+import com.vinculohub.backend.dto.ProjectUpdateRequest;
 import com.vinculohub.backend.exception.BadRequestException;
+import com.vinculohub.backend.exception.ForbiddenException;
 import com.vinculohub.backend.exception.NotFoundException;
 import com.vinculohub.backend.exception.UserNotFoundException;
 import com.vinculohub.backend.model.Npo;
@@ -321,6 +324,202 @@ class ProjectServiceTest {
                 .endDate(LocalDate.of(2026, 12, 20))
                 .odsIds(List.of(1, 2))
                 .build();
+    }
+
+    @Test
+    @DisplayName("Deve atualizar projeto com sucesso")
+    void shouldUpdateProjectSuccessfully() {
+        String auth0Id = "auth0|npo";
+        Long projectId = 30L;
+        User user = User.builder().id(10).auth0Id(auth0Id).build();
+        Npo npo = Npo.builder().id(20).name("ONG Exemplo").build();
+        Project existingProject = Project.builder()
+                .id(projectId)
+                .title("Título antigo")
+                .description("Descrição antiga com pelo menos cinquenta caracteres aqui")
+                .budgetNeeded(new BigDecimal("500.00"))
+                .type(ProjectType.SOCIAL_INVESTMENT_LAW)
+                .npo(npo)
+                .ods(new LinkedHashSet<>())
+                .build();
+
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Título novo",
+                "Descrição nova com impacto mensurável e escopo bem definido.",
+                new BigDecimal("1500.00"),
+                LocalDate.of(2026, 6, 1),
+                LocalDate.of(2027, 1, 1),
+                List.of(1, 2),
+                ProjectType.CULTURAL,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        Set<Ods> ods = new LinkedHashSet<>(
+                List.of(
+                        Ods.builder().id(1).name("ODS 1").description("Desc 1").build(),
+                        Ods.builder().id(2).name("ODS 2").description("Desc 2").build()));
+
+        when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
+        when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npo));
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(existingProject));
+        when(odsService.resolveSelection(List.of("1", "2"))).thenReturn(ods);
+        when(projectRepository.save(any(Project.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        Project updated = projectService.updateProject(auth0Id, projectId, updateRequest);
+
+        assertEquals("Título novo", updated.getTitle());
+        assertEquals("Descrição nova com impacto mensurável e escopo bem definido.", updated.getDescription());
+        assertEquals(new BigDecimal("1500.00"), updated.getBudgetNeeded());
+        assertEquals(ProjectType.CULTURAL, updated.getType());
+        assertEquals(ods, updated.getOds());
+
+        verify(projectRepository).save(any(Project.class));
+    }
+
+    @Test
+    @DisplayName("Deve lançar NotFoundException quando projeto não existe")
+    void shouldThrowNotFoundExceptionWhenUpdatingNonExistentProject() {
+        String auth0Id = "auth0|npo";
+        User user = User.builder().id(10).auth0Id(auth0Id).build();
+        Npo npo = Npo.builder().id(20).name("ONG Exemplo").build();
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Título novo",
+                "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                new BigDecimal("1000.00"),
+                null,
+                null,
+                List.of(1),
+                ProjectType.CULTURAL,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
+        when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npo));
+        when(projectRepository.findById(99L)).thenReturn(Optional.empty());
+
+        NotFoundException exception = assertThrows(
+                NotFoundException.class,
+                () -> projectService.updateProject(auth0Id, 99L, updateRequest));
+
+        assertEquals("Projeto não encontrado.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Deve lançar ForbiddenException quando ONG não é proprietária do projeto")
+    void shouldThrowForbiddenExceptionWhenNpoIsNotOwner() {
+        String auth0Id = "auth0|npo";
+        Long projectId = 30L;
+        User user = User.builder().id(10).auth0Id(auth0Id).build();
+        Npo npoAutenticada = Npo.builder().id(20).name("ONG Exemplo").build();
+        Npo npoProprietaria = Npo.builder().id(99).name("ONG Proprietária").build();
+        
+        Project existingProject = Project.builder()
+                .id(projectId)
+                .title("Título original")
+                .description("Descrição original com pelo menos cinquenta caracteres aqui")
+                .budgetNeeded(new BigDecimal("500.00"))
+                .type(ProjectType.SOCIAL_INVESTMENT_LAW)
+                .npo(npoProprietaria)
+                .build();
+
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Título novo",
+                "Descrição nova com impacto mensurável e escopo bem definido.",
+                new BigDecimal("1500.00"),
+                null,
+                null,
+                List.of(1),
+                ProjectType.CULTURAL,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
+        when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npoAutenticada));
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(existingProject));
+
+        ForbiddenException exception = assertThrows(
+                ForbiddenException.class,
+                () -> projectService.updateProject(auth0Id, projectId, updateRequest));
+
+        assertEquals("Você não tem permissão para atualizar este projeto.", exception.getMessage());
+        verify(projectRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Deve lançar BadRequestException quando ODS é inválido na atualização")
+    void shouldThrowBadRequestExceptionWhenOdsIsInvalidOnUpdate() {
+        String auth0Id = "auth0|npo";
+        Long projectId = 30L;
+        User user = User.builder().id(10).auth0Id(auth0Id).build();
+        Npo npo = Npo.builder().id(20).name("ONG Exemplo").build();
+        Project existingProject = Project.builder()
+                .id(projectId)
+                .title("Título original")
+                .description("Descrição original com pelo menos cinquenta caracteres aqui")
+                .budgetNeeded(new BigDecimal("500.00"))
+                .type(ProjectType.SOCIAL_INVESTMENT_LAW)
+                .npo(npo)
+                .build();
+
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Título novo",
+                "Descrição nova com impacto mensurável e escopo bem definido.",
+                new BigDecimal("1500.00"),
+                null,
+                null,
+                List.of(1, 99),
+                ProjectType.CULTURAL,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
+        when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npo));
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(existingProject));
+        when(odsService.resolveSelection(List.of("1", "99")))
+                .thenThrow(new IllegalArgumentException("ODS inválido"));
+
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> projectService.updateProject(auth0Id, projectId, updateRequest));
+
+        assertEquals("ODS inválido", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("Deve lançar BadRequestException quando auth0Id é nulo na atualização")
+    void shouldThrowBadRequestExceptionWhenAuth0IdIsNullOnUpdate() {
+        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
+                "Título novo",
+                "Descrição nova com impacto mensurável e escopo bem definido.",
+                new BigDecimal("1500.00"),
+                null,
+                null,
+                List.of(1),
+                ProjectType.CULTURAL,
+                null,
+                null,
+                null,
+                null,
+                null);
+
+        BadRequestException exception = assertThrows(
+                BadRequestException.class,
+                () -> projectService.updateProject(null, 30L, updateRequest));
+
+        assertEquals("Não foi possível identificar o usuário autenticado.", exception.getMessage());
     }
 
     private static ProjectCreateRequest invalidOdsRequest() {

--- a/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
@@ -410,9 +410,10 @@ class ProjectServiceTest {
         when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npo));
         when(projectRepository.findById(99L)).thenReturn(Optional.empty());
 
-        NotFoundException exception = assertThrows(
-                NotFoundException.class,
-                () -> projectService.updateProject(auth0Id, 99L, updateRequest));
+        NotFoundException exception =
+                assertThrows(
+                        NotFoundException.class,
+                        () -> projectService.updateProject(auth0Id, 99L, updateRequest));
 
         assertEquals("Projeto não encontrado.", exception.getMessage());
     }
@@ -455,9 +456,10 @@ class ProjectServiceTest {
         when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npoAutenticada));
         when(projectRepository.findById(projectId)).thenReturn(Optional.of(existingProject));
 
-        ForbiddenException exception = assertThrows(
-                ForbiddenException.class,
-                () -> projectService.updateProject(auth0Id, projectId, updateRequest));
+        ForbiddenException exception =
+                assertThrows(
+                        ForbiddenException.class,
+                        () -> projectService.updateProject(auth0Id, projectId, updateRequest));
 
         assertEquals("Você não tem permissão para atualizar este projeto.", exception.getMessage());
         verify(projectRepository, never()).save(any());
@@ -501,9 +503,10 @@ class ProjectServiceTest {
         when(odsService.resolveSelection(List.of("1", "99")))
                 .thenThrow(new IllegalArgumentException("ODS inválido"));
 
-        BadRequestException exception = assertThrows(
-                BadRequestException.class,
-                () -> projectService.updateProject(auth0Id, projectId, updateRequest));
+        BadRequestException exception =
+                assertThrows(
+                        BadRequestException.class,
+                        () -> projectService.updateProject(auth0Id, projectId, updateRequest));
 
         assertEquals("ODS inválido", exception.getMessage());
     }
@@ -526,9 +529,10 @@ class ProjectServiceTest {
                         null,
                         null);
 
-        BadRequestException exception = assertThrows(
-                BadRequestException.class,
-                () -> projectService.updateProject(null, 30L, updateRequest));
+        BadRequestException exception =
+                assertThrows(
+                        BadRequestException.class,
+                        () -> projectService.updateProject(null, 30L, updateRequest));
 
         assertEquals("Não foi possível identificar o usuário autenticado.", exception.getMessage());
     }

--- a/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/ProjectServiceTest.java
@@ -333,34 +333,37 @@ class ProjectServiceTest {
         Long projectId = 30L;
         User user = User.builder().id(10).auth0Id(auth0Id).build();
         Npo npo = Npo.builder().id(20).name("ONG Exemplo").build();
-        Project existingProject = Project.builder()
-                .id(projectId)
-                .title("Título antigo")
-                .description("Descrição antiga com pelo menos cinquenta caracteres aqui")
-                .budgetNeeded(new BigDecimal("500.00"))
-                .type(ProjectType.SOCIAL_INVESTMENT_LAW)
-                .npo(npo)
-                .ods(new LinkedHashSet<>())
-                .build();
+        Project existingProject =
+                Project.builder()
+                        .id(projectId)
+                        .title("Título antigo")
+                        .description("Descrição antiga com pelo menos cinquenta caracteres aqui")
+                        .budgetNeeded(new BigDecimal("500.00"))
+                        .type(ProjectType.SOCIAL_INVESTMENT_LAW)
+                        .npo(npo)
+                        .ods(new LinkedHashSet<>())
+                        .build();
 
-        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
-                "Título novo",
-                "Descrição nova com impacto mensurável e escopo bem definido.",
-                new BigDecimal("1500.00"),
-                LocalDate.of(2026, 6, 1),
-                LocalDate.of(2027, 1, 1),
-                List.of(1, 2),
-                ProjectType.CULTURAL,
-                null,
-                null,
-                null,
-                null,
-                null);
+        ProjectUpdateRequest updateRequest =
+                new ProjectUpdateRequest(
+                        "Título novo",
+                        "Descrição nova com impacto mensurável e escopo bem definido.",
+                        new BigDecimal("1500.00"),
+                        LocalDate.of(2026, 6, 1),
+                        LocalDate.of(2027, 1, 1),
+                        List.of(1, 2),
+                        ProjectType.CULTURAL,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
 
-        Set<Ods> ods = new LinkedHashSet<>(
-                List.of(
-                        Ods.builder().id(1).name("ODS 1").description("Desc 1").build(),
-                        Ods.builder().id(2).name("ODS 2").description("Desc 2").build()));
+        Set<Ods> ods =
+                new LinkedHashSet<>(
+                        List.of(
+                                Ods.builder().id(1).name("ODS 1").description("Desc 1").build(),
+                                Ods.builder().id(2).name("ODS 2").description("Desc 2").build()));
 
         when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
         when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npo));
@@ -372,7 +375,9 @@ class ProjectServiceTest {
         Project updated = projectService.updateProject(auth0Id, projectId, updateRequest);
 
         assertEquals("Título novo", updated.getTitle());
-        assertEquals("Descrição nova com impacto mensurável e escopo bem definido.", updated.getDescription());
+        assertEquals(
+                "Descrição nova com impacto mensurável e escopo bem definido.",
+                updated.getDescription());
         assertEquals(new BigDecimal("1500.00"), updated.getBudgetNeeded());
         assertEquals(ProjectType.CULTURAL, updated.getType());
         assertEquals(ods, updated.getOds());
@@ -386,19 +391,20 @@ class ProjectServiceTest {
         String auth0Id = "auth0|npo";
         User user = User.builder().id(10).auth0Id(auth0Id).build();
         Npo npo = Npo.builder().id(20).name("ONG Exemplo").build();
-        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
-                "Título novo",
-                "Descrição nova com pelo menos cinquenta caracteres válidos.",
-                new BigDecimal("1000.00"),
-                null,
-                null,
-                List.of(1),
-                ProjectType.CULTURAL,
-                null,
-                null,
-                null,
-                null,
-                null);
+        ProjectUpdateRequest updateRequest =
+                new ProjectUpdateRequest(
+                        "Título novo",
+                        "Descrição nova com pelo menos cinquenta caracteres válidos.",
+                        new BigDecimal("1000.00"),
+                        null,
+                        null,
+                        List.of(1),
+                        ProjectType.CULTURAL,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
 
         when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
         when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npo));
@@ -419,29 +425,31 @@ class ProjectServiceTest {
         User user = User.builder().id(10).auth0Id(auth0Id).build();
         Npo npoAutenticada = Npo.builder().id(20).name("ONG Exemplo").build();
         Npo npoProprietaria = Npo.builder().id(99).name("ONG Proprietária").build();
-        
-        Project existingProject = Project.builder()
-                .id(projectId)
-                .title("Título original")
-                .description("Descrição original com pelo menos cinquenta caracteres aqui")
-                .budgetNeeded(new BigDecimal("500.00"))
-                .type(ProjectType.SOCIAL_INVESTMENT_LAW)
-                .npo(npoProprietaria)
-                .build();
 
-        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
-                "Título novo",
-                "Descrição nova com impacto mensurável e escopo bem definido.",
-                new BigDecimal("1500.00"),
-                null,
-                null,
-                List.of(1),
-                ProjectType.CULTURAL,
-                null,
-                null,
-                null,
-                null,
-                null);
+        Project existingProject =
+                Project.builder()
+                        .id(projectId)
+                        .title("Título original")
+                        .description("Descrição original com pelo menos cinquenta caracteres aqui")
+                        .budgetNeeded(new BigDecimal("500.00"))
+                        .type(ProjectType.SOCIAL_INVESTMENT_LAW)
+                        .npo(npoProprietaria)
+                        .build();
+
+        ProjectUpdateRequest updateRequest =
+                new ProjectUpdateRequest(
+                        "Título novo",
+                        "Descrição nova com impacto mensurável e escopo bem definido.",
+                        new BigDecimal("1500.00"),
+                        null,
+                        null,
+                        List.of(1),
+                        ProjectType.CULTURAL,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
 
         when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
         when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npoAutenticada));
@@ -462,28 +470,30 @@ class ProjectServiceTest {
         Long projectId = 30L;
         User user = User.builder().id(10).auth0Id(auth0Id).build();
         Npo npo = Npo.builder().id(20).name("ONG Exemplo").build();
-        Project existingProject = Project.builder()
-                .id(projectId)
-                .title("Título original")
-                .description("Descrição original com pelo menos cinquenta caracteres aqui")
-                .budgetNeeded(new BigDecimal("500.00"))
-                .type(ProjectType.SOCIAL_INVESTMENT_LAW)
-                .npo(npo)
-                .build();
+        Project existingProject =
+                Project.builder()
+                        .id(projectId)
+                        .title("Título original")
+                        .description("Descrição original com pelo menos cinquenta caracteres aqui")
+                        .budgetNeeded(new BigDecimal("500.00"))
+                        .type(ProjectType.SOCIAL_INVESTMENT_LAW)
+                        .npo(npo)
+                        .build();
 
-        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
-                "Título novo",
-                "Descrição nova com impacto mensurável e escopo bem definido.",
-                new BigDecimal("1500.00"),
-                null,
-                null,
-                List.of(1, 99),
-                ProjectType.CULTURAL,
-                null,
-                null,
-                null,
-                null,
-                null);
+        ProjectUpdateRequest updateRequest =
+                new ProjectUpdateRequest(
+                        "Título novo",
+                        "Descrição nova com impacto mensurável e escopo bem definido.",
+                        new BigDecimal("1500.00"),
+                        null,
+                        null,
+                        List.of(1, 99),
+                        ProjectType.CULTURAL,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
 
         when(userRepository.findByAuth0Id(auth0Id)).thenReturn(Optional.of(user));
         when(npoRepository.findByUserId(10)).thenReturn(Optional.of(npo));
@@ -501,19 +511,20 @@ class ProjectServiceTest {
     @Test
     @DisplayName("Deve lançar BadRequestException quando auth0Id é nulo na atualização")
     void shouldThrowBadRequestExceptionWhenAuth0IdIsNullOnUpdate() {
-        ProjectUpdateRequest updateRequest = new ProjectUpdateRequest(
-                "Título novo",
-                "Descrição nova com impacto mensurável e escopo bem definido.",
-                new BigDecimal("1500.00"),
-                null,
-                null,
-                List.of(1),
-                ProjectType.CULTURAL,
-                null,
-                null,
-                null,
-                null,
-                null);
+        ProjectUpdateRequest updateRequest =
+                new ProjectUpdateRequest(
+                        "Título novo",
+                        "Descrição nova com impacto mensurável e escopo bem definido.",
+                        new BigDecimal("1500.00"),
+                        null,
+                        null,
+                        List.of(1),
+                        ProjectType.CULTURAL,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
 
         BadRequestException exception = assertThrows(
                 BadRequestException.class,


### PR DESCRIPTION
## Issue Link
Closes #

## Description
Adicionado o endpoint para atualização de projetos de ONG, criado o DTO, implementada a regra de que apenas a ONG dona do projeto pode atualizá-lo, adicionado tratamento para retorno 403 quando a ONG autenticada não é proprietária do projeto, incluídos testes de serviço e controller.

## Task Notes
## Screenshots