### PR TITLE
fix/admin-dashboard-buttons

### DIFF
--- a/frontend/src/components/general/FlexibleButton.test.tsx
+++ b/frontend/src/components/general/FlexibleButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import AddIcon from "@mui/icons-material/Add";
+import { describe, expect, it } from "vitest";
+import { FlexibleButton } from "./FlexibleButton";
+
+describe("FlexibleButton", () => {
+  it("renderiza um botão independente com ícone obrigatório", () => {
+    render(
+      <FlexibleButton icon={<AddIcon data-testid="flexible-button-icon" />}>
+        Novo item
+      </FlexibleButton>,
+    )
+
+    const button = screen.getByRole("button", { name: "Novo item" })
+
+    expect(button).toHaveAttribute("type", "button")
+    expect(button).toHaveClass("inline-flex")
+    expect(button).toHaveClass("items-center")
+    expect(button).toHaveClass("justify-center")
+    expect(button).toHaveClass("gap-2")
+    expect(button).toHaveClass("rounded-full")
+    expect(button).toHaveClass("border-2")
+    expect(button).toHaveClass("px-4")
+    expect(button).toHaveClass("py-2")
+    expect(button).toHaveClass("text-sm")
+    expect(button).toHaveClass("leading-5")
+    expect(screen.getByTestId("flexible-button-icon")).toHaveClass("h-4")
+    expect(screen.getByTestId("flexible-button-icon")).toHaveClass("w-4")
+  })
+
+  it("aplica a variante visual padrão", () => {
+    render(
+      <FlexibleButton
+        icon={<AddIcon data-testid="flexible-button-icon" />}
+        variant="outline"
+      >
+        Novo item
+      </FlexibleButton>,
+    )
+
+    const button = screen.getByRole("button", { name: "Novo item" })
+
+    expect(button).toHaveClass("bg-white")
+    expect(button).toHaveClass("text-vinculo-dark")
+    expect(button).toHaveClass("border-vinculo-dark")
+  })
+})

--- a/frontend/src/components/general/FlexibleButton.test.tsx
+++ b/frontend/src/components/general/FlexibleButton.test.tsx
@@ -4,6 +4,13 @@ import { describe, expect, it } from "vitest";
 import { FlexibleButton } from "./FlexibleButton";
 
 describe("FlexibleButton", () => {
+  it("exige um ícone", () => {
+    // @ts-expect-error FlexibleButton requer icon
+    const invalidButton = <FlexibleButton>Sem ícone</FlexibleButton>
+
+    expect(invalidButton).toBeDefined()
+  })
+
   it("renderiza um botão independente com ícone obrigatório", () => {
     render(
       <FlexibleButton icon={<AddIcon data-testid="flexible-button-icon" />}>

--- a/frontend/src/components/general/FlexibleButton.tsx
+++ b/frontend/src/components/general/FlexibleButton.tsx
@@ -2,6 +2,7 @@ import {
   cloneElement,
   type ButtonHTMLAttributes,
   type ReactElement,
+  type SVGProps,
 } from "react";
 
 type FlexibleButtonVariant =
@@ -15,7 +16,7 @@ type FlexibleButtonVariant =
 export interface FlexibleButtonProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> {
   variant?: FlexibleButtonVariant;
-  icon: ReactElement;
+  icon: ReactElement<SVGProps<SVGSVGElement>>;
 }
 
 const VARIANT_CLASSES: Record<FlexibleButtonVariant, string> = {

--- a/frontend/src/components/general/FlexibleButton.tsx
+++ b/frontend/src/components/general/FlexibleButton.tsx
@@ -1,0 +1,72 @@
+import {
+  cloneElement,
+  type ButtonHTMLAttributes,
+  type ReactElement,
+} from "react";
+
+type FlexibleButtonVariant =
+  | "primary"
+  | "secondary"
+  | "outline"
+  | "ghost"
+  | "attention"
+  | "warning";
+
+export interface FlexibleButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "className"> {
+  variant?: FlexibleButtonVariant;
+  icon: ReactElement;
+}
+
+const VARIANT_CLASSES: Record<FlexibleButtonVariant, string> = {
+  primary: "bg-vinculo-dark text-white border-vinculo-dark",
+  secondary: "bg-vinculo-green text-white border-vinculo-green",
+  outline: "bg-white text-vinculo-dark border-vinculo-dark",
+  ghost: "bg-vinculo-light-gray text-slate-700 border-vinculo-light-gray",
+  attention: "bg-white text-vinculo-red border-vinculo-red",
+  warning: "bg-white text-vinculo-yellow border-vinculo-yellow",
+}
+
+const BASE_CLASSES = [
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "gap-2",
+  "whitespace-nowrap",
+  "rounded-full",
+  "border-2",
+  "px-4",
+  "py-2",
+  "text-sm",
+  "leading-5",
+  "font-semibold",
+  "transition-all",
+  "duration-200",
+  "cursor-pointer",
+  "disabled:cursor-not-allowed",
+  "disabled:opacity-60",
+]
+
+export function FlexibleButton({
+  variant = "secondary",
+  icon,
+  children,
+  type = "button",
+  ...props
+}: FlexibleButtonProps) {
+  const iconElement = cloneElement(icon, {
+    className: [icon.props.className, "h-4 w-4"].filter(Boolean).join(" "),
+    "aria-hidden": true,
+  })
+
+  return (
+    <button
+      type={type}
+      className={[...BASE_CLASSES, VARIANT_CLASSES[variant]].join(" ")}
+      {...props}
+    >
+      {iconElement}
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/pages/AdminDashboard/index.tsx
+++ b/frontend/src/pages/AdminDashboard/index.tsx
@@ -1,12 +1,12 @@
 import CorporateFareOutlinedIcon from "@mui/icons-material/CorporateFareOutlined";
 import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
-//import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
-//import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
-//import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
-//import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined";
+import InsertDriveFileOutlinedIcon from "@mui/icons-material/InsertDriveFileOutlined";
+import FileDownloadOutlinedIcon from "@mui/icons-material/FileDownloadOutlined";
+import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
+import AccessTimeOutlinedIcon from "@mui/icons-material/AccessTimeOutlined";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
 import PendingActionsOutlinedIcon from "@mui/icons-material/PendingActionsOutlined";
-import { BaseButton } from "../../components/general/BaseButton";
+import { FlexibleButton } from "../../components/general/FlexibleButton";
 import { Header } from "../../components/general/Header";
 import { MetricCard } from "../../components/general/MetricCard";
 
@@ -47,7 +47,7 @@ export function AdminDashboard() {
       <Header />
 
       <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
-        <header className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+        <header className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between align-middle">
           <div className="space-y-2">
             <h1 className="text-3xl font-bold leading-tight text-vinculo-dark sm:text-4xl">
               Painel administrativo
@@ -57,11 +57,10 @@ export function AdminDashboard() {
             </p>
           </div>
 
-          <div className="flex flex-wrap gap-3">
-            <BaseButton
-              //icon={<InsertDriveFileOutlinedIcon fontSize="small" />}
+          <div className="flex flex-wrap items-start gap-3 lg:flex-nowrap">
+            <FlexibleButton
+              icon={<InsertDriveFileOutlinedIcon fontSize="small" />}
               variant="secondary"
-              className="rounded-full px-6 py-3 text-sm sm:text-base"
               onClick={() => {
                 document.getElementById("cadastrar-edital")?.scrollIntoView({
                   behavior: "smooth",
@@ -70,12 +69,11 @@ export function AdminDashboard() {
               }}
             >
               Cadastrar Edital
-            </BaseButton>
+            </FlexibleButton>
 
-            <BaseButton
-              //icon={<FileDownloadOutlinedIcon fontSize="small" />}
+            <FlexibleButton
+              icon={<FileDownloadOutlinedIcon fontSize="small" />}
               variant="outline"
-              className="rounded-full px-6 py-3 text-sm sm:text-base"
               onClick={() => {
                 document.getElementById("exportar-dados")?.scrollIntoView({
                   behavior: "smooth",
@@ -84,12 +82,11 @@ export function AdminDashboard() {
               }}
             >
               Exportar Dados
-            </BaseButton>
+            </FlexibleButton>
 
-            <BaseButton
-              //icon={<AccessTimeOutlinedIcon fontSize="small" />}
+            <FlexibleButton
+              icon={<AccessTimeOutlinedIcon fontSize="small" />}
               variant="attention"
-              className="rounded-full px-6 py-3 text-sm sm:text-base"
               onClick={() => {
                 document.getElementById("denuncias")?.scrollIntoView({
                   behavior: "smooth",
@@ -98,12 +95,11 @@ export function AdminDashboard() {
               }}
             >
               Ver Denúncias
-            </BaseButton>
+            </FlexibleButton>
 
-            <BaseButton
-              //icon={<ReportProblemOutlinedIcon fontSize="small" />}
+            <FlexibleButton
+              icon={<ReportProblemOutlinedIcon fontSize="small" />}
               variant="warning"
-              className="rounded-full px-6 py-3 text-sm sm:text-base"
               onClick={() => {
                 document.getElementById("mediacoes")?.scrollIntoView({
                   behavior: "smooth",
@@ -112,7 +108,7 @@ export function AdminDashboard() {
               }}
             >
               Mediações
-            </BaseButton>
+            </FlexibleButton>
           </div>
         </header>
 


### PR DESCRIPTION
## Issue Link
Patches #229 

## Description

add FlexibleButton, for admin dashboard. Change AdminDashboard references to FlexibleButton.

## Task Notes

Ajuste para seguir os mocks realizados no figma, sem alterar o BaseButton, que não recebe icon.

## Screenshots

<img width="1460" height="244" alt="header_buttons_01" src="https://github.com/user-attachments/assets/eacc5327-f5db-4c4e-b0d9-cdd717c26f24" />
