### PR TITLE
FE - Informações da ONG nos detalhes de projetos

### DIFF
--- a/frontend/src/pages/OngProjectsPage/index.test.tsx
+++ b/frontend/src/pages/OngProjectsPage/index.test.tsx
@@ -54,6 +54,7 @@ const mockProjectDetails: ProjectDetails = {
     "Programa de reforço escolar e formação profissionalizante para jovens em situação de vulnerabilidade social.",
   sdgLabels: ["Educação de Qualidade", "Redução das Desigualdades"],
   progressPercent: 75,
+  responsibleInstitution: null,
 }
 
 const mockRefetch = vi.fn()

--- a/frontend/src/pages/ProjectDetailsPage/ProjectDetailsSkeleton.tsx
+++ b/frontend/src/pages/ProjectDetailsPage/ProjectDetailsSkeleton.tsx
@@ -1,5 +1,6 @@
 export function ProjectDetailsSkeleton() {
   return (
+    <>
     <article
       className="bg-white rounded-2xl shadow-[var(--shadow-vinculo)] px-6 sm:px-10 py-8 sm:py-10 border border-slate-100 animate-pulse"
       aria-busy="true"
@@ -54,5 +55,19 @@ export function ProjectDetailsSkeleton() {
         <div className="h-3 w-full rounded-full bg-slate-200" />
       </div>
     </article>
+
+    <div className="mt-6 bg-white rounded-2xl shadow-[var(--shadow-vinculo)] px-6 sm:px-10 py-8 sm:py-10 border border-slate-100 animate-pulse">
+      <div className="h-5 w-52 rounded bg-slate-200 mb-4" />
+      <div className="flex items-start gap-4">
+        <div className="shrink-0 w-14 h-14 rounded-xl bg-slate-200" />
+        <div className="flex-1 space-y-2">
+          <div className="h-5 w-40 rounded bg-slate-200" />
+          <div className="h-4 w-full rounded bg-slate-100" />
+          <div className="h-4 max-w-[80%] rounded bg-slate-100" />
+          <div className="h-4 w-28 rounded bg-slate-100" />
+        </div>
+      </div>
+    </div>
+    </>
   );
 }

--- a/frontend/src/pages/ProjectDetailsPage/ResponsibleInstitutionCard.test.tsx
+++ b/frontend/src/pages/ProjectDetailsPage/ResponsibleInstitutionCard.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ResponsibleInstitutionCard } from "./ResponsibleInstitutionCard";
+import type { ResponsibleInstitution } from "./projectDetails.types";
+
+const baseInstitution: ResponsibleInstitution = {
+  name: "Saúde Solidária",
+  logoUrl: null,
+  city: null,
+  stateCode: null,
+  description: null,
+};
+
+describe("ResponsibleInstitutionCard", () => {
+  it("não renderiza nada quando institution é null", () => {
+    const { container } = render(<ResponsibleInstitutionCard institution={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renderiza o nome da ONG", () => {
+    render(<ResponsibleInstitutionCard institution={baseInstitution} />);
+    expect(screen.getByText("Saúde Solidária")).toBeInTheDocument();
+  });
+
+  it("renderiza o título da seção", () => {
+    render(<ResponsibleInstitutionCard institution={baseInstitution} />);
+    expect(screen.getByText("Organização Responsável")).toBeInTheDocument();
+  });
+
+  it("renderiza descrição quando presente", () => {
+    const institution = { ...baseInstitution, description: "ONG focada em saúde." };
+    render(<ResponsibleInstitutionCard institution={institution} />);
+    expect(screen.getByText("ONG focada em saúde.")).toBeInTheDocument();
+  });
+
+  it("não renderiza descrição quando null", () => {
+    render(<ResponsibleInstitutionCard institution={baseInstitution} />);
+    expect(screen.queryByText(/ONG/)).not.toBeInTheDocument();
+  });
+
+  it("renderiza cidade e UF quando ambos presentes", () => {
+    const institution = { ...baseInstitution, city: "Recife", stateCode: "PE" };
+    render(<ResponsibleInstitutionCard institution={institution} />);
+    expect(screen.getByText("Recife, PE")).toBeInTheDocument();
+  });
+
+  it("renderiza só a cidade quando stateCode é null", () => {
+    const institution = { ...baseInstitution, city: "Recife", stateCode: null };
+    render(<ResponsibleInstitutionCard institution={institution} />);
+    expect(screen.getByText("Recife")).toBeInTheDocument();
+  });
+
+  it("renderiza só o stateCode quando city é null", () => {
+    const institution = { ...baseInstitution, city: null, stateCode: "PE" };
+    render(<ResponsibleInstitutionCard institution={institution} />);
+    expect(screen.getByText("PE")).toBeInTheDocument();
+  });
+
+  it("não renderiza linha de localização quando city e stateCode são null", () => {
+    render(<ResponsibleInstitutionCard institution={baseInstitution} />);
+    expect(screen.queryByText(/,/)).not.toBeInTheDocument();
+  });
+
+  it("renderiza img quando logoUrl está presente", () => {
+    const institution = {
+      ...baseInstitution,
+      logoUrl: "https://example.com/logo.png",
+    };
+    render(<ResponsibleInstitutionCard institution={institution} />);
+    const img = screen.getByRole("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/logo.png");
+    expect(img).toHaveAttribute("alt", "Saúde Solidária");
+  });
+
+  it("renderiza ícone fallback quando logoUrl é null", () => {
+    render(<ResponsibleInstitutionCard institution={baseInstitution} />);
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ProjectDetailsPage/ResponsibleInstitutionCard.tsx
+++ b/frontend/src/pages/ProjectDetailsPage/ResponsibleInstitutionCard.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import ApartmentIcon from "@mui/icons-material/Apartment";
+import LocationOnIcon from "@mui/icons-material/LocationOn";
+import type { ResponsibleInstitution } from "./projectDetails.types";
+
+type Props = {
+  institution: ResponsibleInstitution | null;
+};
+
+function buildLocation(city: string | null, stateCode: string | null): string | null {
+  if (city && stateCode) return `${city}, ${stateCode}`;
+  if (city) return city;
+  if (stateCode) return stateCode;
+  return null;
+}
+
+export function ResponsibleInstitutionCard({ institution }: Props) {
+  const [logoFailed, setLogoFailed] = useState(false);
+
+  if (!institution) return null;
+
+  const { name, logoUrl, city, stateCode, description } = institution;
+  const showLogo = logoUrl && !logoFailed;
+  const location = buildLocation(city, stateCode);
+
+  return (
+    <article className="bg-white rounded-2xl shadow-[var(--shadow-vinculo)] px-6 sm:px-10 py-8 sm:py-10 border border-slate-100">
+      <h2 className="text-base font-bold text-vinculo-dark mb-4">Organização Responsável</h2>
+
+      <div className="flex items-start gap-4">
+        <div className="shrink-0 w-14 h-14 rounded-xl overflow-hidden flex items-center justify-center bg-vinculo-dark">
+          {showLogo ? (
+            <img
+              src={logoUrl}
+              alt={name}
+              className="w-full h-full object-cover"
+              onError={() => setLogoFailed(true)}
+            />
+          ) : (
+            <ApartmentIcon sx={{ fontSize: 28, color: "white" }} aria-hidden />
+          )}
+        </div>
+
+        <div className="min-w-0">
+          <p className="font-bold text-vinculo-dark leading-snug">{name}</p>
+
+          {description && (
+            <p className="text-slate-600 text-sm mt-1 leading-relaxed">{description}</p>
+          )}
+
+          {location && (
+            <p className="flex items-center gap-1 text-slate-500 text-sm mt-2">
+              <LocationOnIcon sx={{ fontSize: 16 }} aria-hidden />
+              {location}
+            </p>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/pages/ProjectDetailsPage/index.test.tsx
+++ b/frontend/src/pages/ProjectDetailsPage/index.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectDetailsPage } from ".";
+import type { ProjectDetails } from "./projectDetails.types";
+
+const mocks = vi.hoisted(() => ({
+  fetchProjectDetailsMock: vi.fn(),
+  getAccessTokenSilentlyMock: vi.fn(),
+}));
+
+vi.mock("@auth0/auth0-react", () => ({
+  useAuth0: () => ({
+    getAccessTokenSilently: mocks.getAccessTokenSilentlyMock,
+    isAuthenticated: true,
+    loginWithRedirect: vi.fn(),
+    logout: vi.fn(),
+    user: { "https://vinculohub/roles": ["COMPANY"] },
+  }),
+}));
+
+vi.mock("./fetchProjectDetails", () => ({
+  fetchProjectDetails: mocks.fetchProjectDetailsMock,
+}));
+
+const baseProject: ProjectDetails = {
+  id: "proj-1",
+  name: "Saúde em Movimento",
+  description: "Unidade móvel de saúde.",
+  fundingType: "Lei de Incentivo",
+  requiredAmount: 75000,
+  sdgLabels: ["Saúde e Bem-Estar"],
+  progressPercent: 40,
+  responsibleInstitution: null,
+};
+
+function renderPage(projectId = "proj-1", locationState?: object) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter
+        initialEntries={[{ pathname: `/projeto/${projectId}`, state: locationState }]}
+      >
+        <Routes>
+          <Route path="/projeto/:projectId" element={<ProjectDetailsPage />} />
+          <Route path="/empresa/dashboard" element={<p>Dashboard da Empresa</p>} />
+          <Route path="/ong/dashboard" element={<p>Dashboard da ONG</p>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ProjectDetailsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getAccessTokenSilentlyMock.mockResolvedValue("token-test");
+    mocks.fetchProjectDetailsMock.mockResolvedValue(baseProject);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("estado de loading", () => {
+    it("exibe skeleton com aria-busy durante carregamento", () => {
+      mocks.fetchProjectDetailsMock.mockReturnValue(new Promise(() => {}));
+      renderPage();
+      expect(screen.getByRole("article", { name: /carregando/i })).toHaveAttribute(
+        "aria-busy",
+        "true",
+      );
+    });
+  });
+
+  describe("estado de erro", () => {
+    it("exibe botão Tentar novamente quando fetch falha", async () => {
+      mocks.fetchProjectDetailsMock.mockRejectedValue(new Error("Network error"));
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /tentar novamente/i })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("projeto não encontrado", () => {
+    it("exibe mensagem de projeto não encontrado", async () => {
+      mocks.fetchProjectDetailsMock.mockResolvedValue(null);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText("Projeto não encontrado")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Lei de Incentivo", () => {
+    it("exibe badge com valor formatado", async () => {
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(/75\.000,00/)).toBeInTheDocument();
+      });
+    });
+
+    it("exibe badge do tipo de financiamento", async () => {
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText("Lei de Incentivo")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Investimento Social Privado", () => {
+    it("não exibe badge de valor monetário", async () => {
+      mocks.fetchProjectDetailsMock.mockResolvedValue({
+        ...baseProject,
+        fundingType: "Investimento Social Privado",
+        requiredAmount: 50000,
+      });
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText("Investimento Social Privado")).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/R\$/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("card de Organização Responsável", () => {
+    it("exibe o card quando responsibleInstitution está preenchida", async () => {
+      mocks.fetchProjectDetailsMock.mockResolvedValue({
+        ...baseProject,
+        responsibleInstitution: {
+          name: "Saúde Solidária",
+          logoUrl: null,
+          city: "Recife",
+          stateCode: "PE",
+          description: "ONG focada em saúde.",
+        },
+      });
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText("Organização Responsável")).toBeInTheDocument();
+        expect(screen.getByText("Saúde Solidária")).toBeInTheDocument();
+      });
+    });
+
+    it("não exibe o card quando responsibleInstitution é null", async () => {
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText("Saúde em Movimento")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Organização Responsável")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("navegação — botão Voltar", () => {
+    it("exibe 'Voltar ao Dashboard' sem returnTo no state", async () => {
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText(/voltar ao dashboard/i)).toBeInTheDocument();
+      });
+    });
+
+    it("exibe 'Voltar aos Projetos' quando returnTo é /ong/projetos", async () => {
+      renderPage("proj-1", { returnTo: "/ong/projetos" });
+      await waitFor(() => {
+        expect(screen.getByText(/voltar aos projetos/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/pages/ProjectDetailsPage/index.tsx
+++ b/frontend/src/pages/ProjectDetailsPage/index.tsx
@@ -10,6 +10,7 @@ import { OdsTags } from "./OdsTags";
 import { ProjectDetailsNotFound } from "./ProjectDetailsNotFound";
 import { ProjectDetailsSkeleton } from "./ProjectDetailsSkeleton";
 import { ProjectHeader } from "./ProjectHeader";
+import { ResponsibleInstitutionCard } from "./ResponsibleInstitutionCard";
 
 function formatBrl(amount: number) {
   return new Intl.NumberFormat("pt-BR", {
@@ -107,6 +108,12 @@ export function ProjectDetailsPage() {
                 <FundingProgress progressPercent={project.progressPercent} />
               )}
             </article>
+          )}
+
+          {Boolean(projectId) && !query.isLoading && !query.isError && project && (
+            <div className="mt-6">
+              <ResponsibleInstitutionCard institution={project.responsibleInstitution} />
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/pages/ProjectDetailsPage/projectDetails.types.ts
+++ b/frontend/src/pages/ProjectDetailsPage/projectDetails.types.ts
@@ -1,3 +1,11 @@
+export type ResponsibleInstitution = {
+  name: string;
+  logoUrl: string | null;
+  city: string | null;
+  stateCode: string | null;
+  description: string | null;
+};
+
 export type ProjectDetails = {
   id: string;
   fundingType: string;
@@ -6,4 +14,5 @@ export type ProjectDetails = {
   description: string;
   sdgLabels: string[];
   progressPercent: number;
+  responsibleInstitution: ResponsibleInstitution | null;
 };

--- a/frontend/src/pages/ProjectDetailsPage/projectDetailsMapping.test.ts
+++ b/frontend/src/pages/ProjectDetailsPage/projectDetailsMapping.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { mapApiPayloadToProjectDetails } from "./projectDetailsMapping";
+
+const ROUTE_ID = "proj-1";
+
+describe("mapApiPayloadToProjectDetails", () => {
+  describe("fundingType — Lei de Incentivo x Investimento Social Privado", () => {
+    it("mapeia TAX_INCENTIVE_LAW para Lei de Incentivo", () => {
+      const result = mapApiPayloadToProjectDetails({ type: "TAX_INCENTIVE_LAW" }, ROUTE_ID);
+      expect(result.fundingType).toBe("Lei de Incentivo");
+    });
+
+    it("mapeia GOVERNMENTAL para Lei de Incentivo", () => {
+      const result = mapApiPayloadToProjectDetails({ type: "GOVERNMENTAL" }, ROUTE_ID);
+      expect(result.fundingType).toBe("Lei de Incentivo");
+    });
+
+    it("mapeia SOCIAL_INVESTMENT_LAW para Investimento Social Privado", () => {
+      const result = mapApiPayloadToProjectDetails({ type: "SOCIAL_INVESTMENT_LAW" }, ROUTE_ID);
+      expect(result.fundingType).toBe("Investimento Social Privado");
+    });
+
+    it("mapeia SOCIAL para Investimento Social Privado", () => {
+      const result = mapApiPayloadToProjectDetails({ type: "SOCIAL" }, ROUTE_ID);
+      expect(result.fundingType).toBe("Investimento Social Privado");
+    });
+
+    it("inclui requiredAmount quando budgetNeeded presente", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { type: "TAX_INCENTIVE_LAW", budgetNeeded: 75000 },
+        ROUTE_ID,
+      );
+      expect(result.requiredAmount).toBe(75000);
+    });
+
+    it("aceita budget_needed em snake_case", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { type: "TAX_INCENTIVE_LAW", budget_needed: 50000 },
+        ROUTE_ID,
+      );
+      expect(result.requiredAmount).toBe(50000);
+    });
+  });
+
+  describe("progressPercent", () => {
+    it("usa progressPercent direto quando presente", () => {
+      const result = mapApiPayloadToProjectDetails({ progressPercent: 42 }, ROUTE_ID);
+      expect(result.progressPercent).toBe(42);
+    });
+
+    it("calcula progress a partir de investedAmount / budgetNeeded", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { budgetNeeded: 100000, investedAmount: 40000 },
+        ROUTE_ID,
+      );
+      expect(result.progressPercent).toBe(40);
+    });
+
+    it("clampa progress em 100", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { budgetNeeded: 100, investedAmount: 200 },
+        ROUTE_ID,
+      );
+      expect(result.progressPercent).toBe(100);
+    });
+
+    it("retorna 0 quando sem dados de progresso", () => {
+      const result = mapApiPayloadToProjectDetails({}, ROUTE_ID);
+      expect(result.progressPercent).toBe(0);
+    });
+  });
+
+  describe("sdgLabels", () => {
+    it("usa sdgLabels direto quando presente", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { sdgLabels: ["Educação de Qualidade"] },
+        ROUTE_ID,
+      );
+      expect(result.sdgLabels).toEqual(["Educação de Qualidade"]);
+    });
+
+    it("extrai nomes de ods[] quando sdgLabels ausente", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { ods: [{ name: "Saúde e Bem-Estar" }] },
+        ROUTE_ID,
+      );
+      expect(result.sdgLabels).toEqual(["Saúde e Bem-Estar"]);
+    });
+
+    it("mapeia odsCodes para nomes ODS quando ods ausente", () => {
+      const result = mapApiPayloadToProjectDetails({ odsCodes: [4] }, ROUTE_ID);
+      expect(result.sdgLabels).toEqual(["Educação de Qualidade"]);
+    });
+  });
+
+  describe("responsibleInstitution", () => {
+    it("retorna null quando campo ausente", () => {
+      const result = mapApiPayloadToProjectDetails({}, ROUTE_ID);
+      expect(result.responsibleInstitution).toBeNull();
+    });
+
+    it("retorna null quando campo é null explícito", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { responsibleInstitution: null },
+        ROUTE_ID,
+      );
+      expect(result.responsibleInstitution).toBeNull();
+    });
+
+    it("retorna null quando name está vazio", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { responsibleInstitution: { name: "", city: "Porto Alegre" } },
+        ROUTE_ID,
+      );
+      expect(result.responsibleInstitution).toBeNull();
+    });
+
+    it("mapeia todos os campos quando presentes", () => {
+      const result = mapApiPayloadToProjectDetails(
+        {
+          responsibleInstitution: {
+            name: "Saúde Solidária",
+            logoUrl: "https://example.com/logo.png",
+            city: "Recife",
+            stateCode: "PE",
+            description: "ONG focada em saúde.",
+          },
+        },
+        ROUTE_ID,
+      );
+      expect(result.responsibleInstitution).toEqual({
+        name: "Saúde Solidária",
+        logoUrl: "https://example.com/logo.png",
+        city: "Recife",
+        stateCode: "PE",
+        description: "ONG focada em saúde.",
+      });
+    });
+
+    it("mapeia campos ausentes como null", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { responsibleInstitution: { name: "ONG Teste" } },
+        ROUTE_ID,
+      );
+      expect(result.responsibleInstitution).toEqual({
+        name: "ONG Teste",
+        logoUrl: null,
+        city: null,
+        stateCode: null,
+        description: null,
+      });
+    });
+
+    it("aceita responsible_institution em snake_case", () => {
+      const result = mapApiPayloadToProjectDetails(
+        { responsible_institution: { name: "ONG Snake" } },
+        ROUTE_ID,
+      );
+      expect(result.responsibleInstitution?.name).toBe("ONG Snake");
+    });
+
+    it("aceita logo_url e state_code em snake_case", () => {
+      const result = mapApiPayloadToProjectDetails(
+        {
+          responsibleInstitution: {
+            name: "ONG Teste",
+            logo_url: "https://example.com/logo.png",
+            state_code: "RS",
+          },
+        },
+        ROUTE_ID,
+      );
+      expect(result.responsibleInstitution?.logoUrl).toBe("https://example.com/logo.png");
+      expect(result.responsibleInstitution?.stateCode).toBe("RS");
+    });
+  });
+});

--- a/frontend/src/pages/ProjectDetailsPage/projectDetailsMapping.ts
+++ b/frontend/src/pages/ProjectDetailsPage/projectDetailsMapping.ts
@@ -1,4 +1,4 @@
-import type { ProjectDetails } from "./projectDetails.types";
+import type { ProjectDetails, ResponsibleInstitution } from "./projectDetails.types";
 
 const ODS_BY_CODE: Record<number, string> = {
   1: "Erradicação da Pobreza",
@@ -85,6 +85,20 @@ function computeProgress(invested: number | null, budget: number | null): number
   return Math.min(100, Math.round((invested / budget) * 100));
 }
 
+function mapResponsibleInstitution(v: unknown): ResponsibleInstitution | null {
+  if (!v || typeof v !== "object") return null;
+  const o = v as UnknownRecord;
+  const name = str(o.name);
+  if (!name) return null;
+  return {
+    name,
+    logoUrl: str(o.logoUrl ?? o.logo_url) || null,
+    city: str(o.city) || null,
+    stateCode: str(o.stateCode ?? o.state_code) || null,
+    description: str(o.description) || null,
+  };
+}
+
 /** Maps API payload (camelCase or snake_case) to view model. */
 export function mapApiPayloadToProjectDetails(raw: unknown, routeId: string): ProjectDetails {
   const o = raw && typeof raw === "object" ? (raw as UnknownRecord) : {};
@@ -120,6 +134,10 @@ export function mapApiPayloadToProjectDetails(raw: unknown, routeId: string): Pr
 
   const fundingType = projectTypeLabel(fundingTypeRaw || backendType);
 
+  const responsibleInstitution = mapResponsibleInstitution(
+    o.responsibleInstitution ?? o.responsible_institution,
+  );
+
   return {
     id,
     fundingType: fundingType || "—",
@@ -128,5 +146,6 @@ export function mapApiPayloadToProjectDetails(raw: unknown, routeId: string): Pr
     description: description || "",
     sdgLabels,
     progressPercent,
+    responsibleInstitution,
   };
 }


### PR DESCRIPTION
## Issue Link
Closes #221

## Description
Implementação do card de **Organização Responsável** na página de detalhes de projeto, consumindo o campo `responsibleInstitution` adicionado pelo PR #234 no backend.

## Task Notes
- Adicionado tipo `ResponsibleInstitution` e campo `responsibleInstitution` no tipo `ProjectDetails`
- Mapper atualizado para ler `responsibleInstitution` / `responsible_institution` (suporte a camelCase e snake_case), mapeando todos os subcampos de forma condicional
- Criado componente `ResponsibleInstitutionCard` com logo (imagem ou ícone fallback), nome, descrição e localização — todos os campos são condicionais: só exibe o que vier do backend
- Card renderizado abaixo do card de detalhes existente na página
- Skeleton atualizado para incluir o shape do novo card durante o loading
- Adicionados testes unitários do mapper, testes do componente isolado e teste de integração da página

## Screenshots
<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/aa48d65a-962c-4acd-a467-223df8e3db60" />
