### PR TITLE
Us/visualizing npo own documents

### DIFF
--- a/backend/src/main/java/com/vinculohub/backend/config/S3Config.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/S3Config.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -17,6 +18,14 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();

--- a/backend/src/main/java/com/vinculohub/backend/controller/DocumentController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/DocumentController.java
@@ -1,6 +1,7 @@
 /* (C)2026 */
 package com.vinculohub.backend.controller;
 
+import com.vinculohub.backend.dto.DocumentDownloadResponseDTO;
 import com.vinculohub.backend.dto.DocumentRequestDTO;
 import com.vinculohub.backend.dto.DocumentResponseDTO;
 import com.vinculohub.backend.service.DocumentService;
@@ -40,6 +41,16 @@ public class DocumentController {
         Page<DocumentResponseDTO> documents =
                 documentService.findAllByAuthenticatedNpo(jwt.getSubject(), pageable);
         return ResponseEntity.ok(documents);
+    }
+
+    @GetMapping("/my-ong/{documentId}/download")
+    @PreAuthorize("hasRole('NPO')")
+    public ResponseEntity<DocumentDownloadResponseDTO> downloadAuthenticatedNpoDocument(
+            @AuthenticationPrincipal Jwt jwt, @PathVariable Integer documentId) {
+        DocumentDownloadResponseDTO response =
+                documentService.generateDownloadUrlForAuthenticatedNpo(
+                        jwt.getSubject(), documentId);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping

--- a/backend/src/main/java/com/vinculohub/backend/dto/DocumentDownloadResponseDTO.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/DocumentDownloadResponseDTO.java
@@ -1,0 +1,7 @@
+/* (C)2026 */
+package com.vinculohub.backend.dto;
+
+import java.time.Instant;
+
+public record DocumentDownloadResponseDTO(
+        String downloadUrl, String fileName, String mimeType, Instant expiresAt) {}

--- a/backend/src/main/java/com/vinculohub/backend/repository/DocumentRepository.java
+++ b/backend/src/main/java/com/vinculohub/backend/repository/DocumentRepository.java
@@ -3,6 +3,7 @@ package com.vinculohub.backend.repository;
 
 import com.vinculohub.backend.model.Document;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,8 @@ public interface DocumentRepository extends JpaRepository<Document, Integer> {
     List<Document> findByNpo_Id(Integer npoId);
 
     Page<Document> findByNpo_Id(Integer npoId, Pageable pageable);
+
+    Optional<Document> findByIdAndNpo_Id(Integer id, Integer npoId);
 
     List<Document> findByProject_Id(Integer projectId);
 

--- a/backend/src/main/java/com/vinculohub/backend/service/DocumentService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/DocumentService.java
@@ -1,6 +1,7 @@
 /* (C)2026 */
 package com.vinculohub.backend.service;
 
+import com.vinculohub.backend.dto.DocumentDownloadResponseDTO;
 import com.vinculohub.backend.dto.DocumentRequestDTO;
 import com.vinculohub.backend.dto.DocumentResponseDTO;
 import com.vinculohub.backend.exception.BadRequestException;
@@ -18,6 +19,8 @@ import com.vinculohub.backend.repository.ProjectRepository;
 import com.vinculohub.backend.repository.UserRepository;
 import com.vinculohub.backend.service.storage.S3Uploader;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -38,6 +41,8 @@ public class DocumentService {
     private final S3Uploader s3Uploader;
 
     private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+    private static final Duration DOWNLOAD_URL_TTL = Duration.ofMinutes(10);
 
     private static final List<String> ALLOWED_TYPES =
             List.of(
@@ -129,6 +134,36 @@ public class DocumentService {
                         .orElseThrow(() -> new NotFoundException("ONG nao encontrada"));
 
         return documentRepository.findByNpo_Id(npo.getId(), pageable).map(this::mapToResponse);
+    }
+
+    public DocumentDownloadResponseDTO generateDownloadUrlForAuthenticatedNpo(
+            String auth0Id, Integer documentId) {
+        if (auth0Id == null || auth0Id.isBlank()) {
+            throw new BadRequestException("Nao foi possivel identificar o usuario autenticado.");
+        }
+        if (documentId == null) {
+            throw new BadRequestException("Document id is required");
+        }
+
+        User user = userRepository.findByAuth0Id(auth0Id).orElseThrow(UserNotFoundException::new);
+        Npo npo =
+                npoRepository
+                        .findByUserId(user.getId())
+                        .orElseThrow(() -> new NotFoundException("ONG nao encontrada"));
+
+        Document document =
+                documentRepository
+                        .findByIdAndNpo_Id(documentId, npo.getId())
+                        .orElseThrow(() -> new NotFoundException("Documento nao encontrado"));
+
+        String downloadUrl =
+                s3Uploader.generatePresignedDownloadUrl(document.getFileUrl(), DOWNLOAD_URL_TTL);
+
+        return new DocumentDownloadResponseDTO(
+                downloadUrl,
+                document.getFileName(),
+                document.getMimeType(),
+                Instant.now().plus(DOWNLOAD_URL_TTL));
     }
 
     private DocumentResponseDTO mapToResponse(Document document) {

--- a/backend/src/main/java/com/vinculohub/backend/service/storage/S3Uploader.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/storage/S3Uploader.java
@@ -1,7 +1,12 @@
 /* (C)2026 */
 package com.vinculohub.backend.service.storage;
 
+import com.vinculohub.backend.exception.BadRequestException;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,13 +14,17 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 @Component
 @RequiredArgsConstructor
 public class S3Uploader {
 
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
 
     @Value("${AWS_S3_BUCKET}")
     private String bucketName;
@@ -35,5 +44,33 @@ public class S3Uploader {
                 RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
         return String.format("https://%s.s3.amazonaws.com/%s", bucketName, fileName);
+    }
+
+    public String generatePresignedDownloadUrl(String fileUrl, Duration duration) {
+        String key = extractObjectKeyFromUrl(fileUrl);
+
+        GetObjectRequest getObjectRequest =
+                GetObjectRequest.builder().bucket(bucketName).key(key).build();
+        GetObjectPresignRequest presignRequest =
+                GetObjectPresignRequest.builder()
+                        .signatureDuration(duration)
+                        .getObjectRequest(getObjectRequest)
+                        .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
+    private String extractObjectKeyFromUrl(String fileUrl) {
+        if (fileUrl == null || fileUrl.isBlank()) {
+            throw new BadRequestException("Document file URL is invalid");
+        }
+
+        URI uri = URI.create(fileUrl);
+        String path = uri.getPath();
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            throw new BadRequestException("Document file URL is invalid");
+        }
+
+        return URLDecoder.decode(path.substring(1), StandardCharsets.UTF_8);
     }
 }

--- a/backend/src/test/java/com/vinculohub/backend/service/DocumentServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/DocumentServiceTest.java
@@ -4,6 +4,7 @@ package com.vinculohub.backend.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.vinculohub.backend.dto.DocumentDownloadResponseDTO;
 import com.vinculohub.backend.dto.DocumentRequestDTO;
 import com.vinculohub.backend.dto.DocumentResponseDTO;
 import com.vinculohub.backend.exception.BadRequestException;
@@ -20,6 +21,7 @@ import com.vinculohub.backend.repository.ProjectRepository;
 import com.vinculohub.backend.repository.UserRepository;
 import com.vinculohub.backend.service.storage.S3Uploader;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -291,5 +293,55 @@ class DocumentServiceTest {
                 () ->
                         documentService.findAllByAuthenticatedNpo(
                                 "auth0|123", PageRequest.of(0, 20)));
+    }
+
+    @Test
+    void shouldGenerateDownloadUrlForAuthenticatedNpoDocument() {
+        User user = new User();
+        user.setId(20);
+
+        Npo npo = new Npo();
+        npo.setId(1);
+
+        Document document = new Document();
+        document.setId(10);
+        document.setNpo(npo);
+        document.setFileUrl("https://bucket.s3.amazonaws.com/npo/1/file.pdf");
+        document.setFileName("file.pdf");
+        document.setMimeType("application/pdf");
+
+        when(userRepository.findByAuth0Id("auth0|123")).thenReturn(Optional.of(user));
+        when(npoRepository.findByUserId(20)).thenReturn(Optional.of(npo));
+        when(documentRepository.findByIdAndNpo_Id(10, 1)).thenReturn(Optional.of(document));
+        when(s3Uploader.generatePresignedDownloadUrl(
+                        eq("https://bucket.s3.amazonaws.com/npo/1/file.pdf"), any(Duration.class)))
+                .thenReturn("https://signed-url");
+
+        DocumentDownloadResponseDTO result =
+                documentService.generateDownloadUrlForAuthenticatedNpo("auth0|123", 10);
+
+        assertEquals("https://signed-url", result.downloadUrl());
+        assertEquals("file.pdf", result.fileName());
+        assertEquals("application/pdf", result.mimeType());
+        assertNotNull(result.expiresAt());
+    }
+
+    @Test
+    void shouldNotGenerateDownloadUrlForDocumentFromAnotherNpo() {
+        User user = new User();
+        user.setId(20);
+
+        Npo npo = new Npo();
+        npo.setId(1);
+
+        when(userRepository.findByAuth0Id("auth0|123")).thenReturn(Optional.of(user));
+        when(npoRepository.findByUserId(20)).thenReturn(Optional.of(npo));
+        when(documentRepository.findByIdAndNpo_Id(10, 1)).thenReturn(Optional.empty());
+
+        assertThrows(
+                NotFoundException.class,
+                () -> documentService.generateDownloadUrlForAuthenticatedNpo("auth0|123", 10));
+
+        verify(s3Uploader, never()).generatePresignedDownloadUrl(anyString(), any());
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,8 @@ services:
     image: flyway/flyway:9
     container_name: flyway
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - ./backend/src/main/resources/db/migration:/flyway/sql:ro
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,7 @@ services:
     image: flyway/flyway:9
     container_name: flyway
     depends_on:
-      db:
-        condition: service_healthy
+      - db
     volumes:
       - ./backend/src/main/resources/db/migration:/flyway/sql:ro
     command: >

--- a/frontend/src/api/document.ts
+++ b/frontend/src/api/document.ts
@@ -19,6 +19,21 @@ export interface DocumentResponseDTO {
   deletedAt?: string | null;
 }
 
+export interface DocumentDownloadResponseDTO {
+  downloadUrl: string;
+  fileName: string;
+  mimeType: string;
+  expiresAt: string;
+}
+
+export interface PaginatedDocumentsResponse {
+  content: DocumentResponseDTO[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+}
+
 /**
  * Interface baseada no DocumentRequestDTO
  */
@@ -75,6 +90,54 @@ export async function uploadDocument(
     return data;
   } catch (error) {
     logger.error("DocumentAPI", "Falha no upload do documento", error);
+    throw error;
+  }
+}
+
+export async function fetchMyOngDocuments(
+  token: string,
+  page = 0,
+  size = 20,
+): Promise<PaginatedDocumentsResponse> {
+  logger.info("DocumentAPI", "Buscando documentos privados da ONG", { page, size });
+
+  try {
+    const { data } = await api.get<PaginatedDocumentsResponse>(
+      "/api/documents/my-ong",
+      {
+        params: { page, size },
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    logger.info("DocumentAPI", "Documentos privados carregados", {
+      totalElements: data.totalElements,
+    });
+    return data;
+  } catch (error) {
+    logger.error("DocumentAPI", "Falha ao buscar documentos privados da ONG", error);
+    throw error;
+  }
+}
+
+export async function getMyOngDocumentDownloadUrl(
+  documentId: number,
+  token: string,
+): Promise<DocumentDownloadResponseDTO> {
+  logger.info("DocumentAPI", "Solicitando URL de download do documento", { documentId });
+
+  try {
+    const { data } = await api.get<DocumentDownloadResponseDTO>(
+      `/api/documents/my-ong/${documentId}/download`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+
+    logger.info("DocumentAPI", "URL de download gerada com sucesso", { documentId });
+    return data;
+  } catch (error) {
+    logger.error("DocumentAPI", "Falha ao gerar URL de download do documento", error);
     throw error;
   }
 }

--- a/frontend/src/pages/OngProfilePage/PrivateDocumentsCard.tsx
+++ b/frontend/src/pages/OngProfilePage/PrivateDocumentsCard.tsx
@@ -1,0 +1,156 @@
+import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined"
+import DownloadOutlinedIcon from "@mui/icons-material/DownloadOutlined"
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined"
+import { useAuth0 } from "@auth0/auth0-react"
+import { useEffect, useState } from "react"
+import {
+  fetchMyOngDocuments,
+  getMyOngDocumentDownloadUrl,
+  type DocumentResponseDTO,
+} from "../../api/document"
+
+function formatFileSize(bytes: number | null | undefined) {
+  if (!bytes || bytes <= 0) return "Tamanho indisponível"
+  const units = ["B", "KB", "MB", "GB"]
+  let value = bytes
+  let unitIndex = 0
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+
+  return `${value.toLocaleString("pt-BR", {
+    maximumFractionDigits: unitIndex === 0 ? 0 : 1,
+  })} ${units[unitIndex]}`
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "Data indisponível"
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "Data indisponível"
+
+  return new Intl.DateTimeFormat("pt-BR").format(date)
+}
+
+export function PrivateDocumentsCard() {
+  const { getAccessTokenSilently } = useAuth0()
+  const [documents, setDocuments] = useState<DocumentResponseDTO[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [downloadingId, setDownloadingId] = useState<number | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadDocuments() {
+      try {
+        setLoading(true)
+        setError(null)
+        const token = await getAccessTokenSilently()
+        const response = await fetchMyOngDocuments(token)
+        if (!cancelled) setDocuments(response.content)
+      } catch {
+        if (!cancelled) setError("Não foi possível carregar os documentos.")
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void loadDocuments()
+
+    return () => {
+      cancelled = true
+    }
+  }, [getAccessTokenSilently])
+
+  async function handleDownload(documentId: number) {
+    try {
+      setDownloadingId(documentId)
+      const token = await getAccessTokenSilently()
+      const response = await getMyOngDocumentDownloadUrl(documentId, token)
+      window.open(response.downloadUrl, "_blank", "noopener,noreferrer")
+    } catch {
+      setError("Não foi possível gerar o link de download.")
+    } finally {
+      setDownloadingId(null)
+    }
+  }
+
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-center gap-2">
+          <LockOutlinedIcon fontSize="small" className="text-vinculo-dark" />
+          <h2 className="text-base font-semibold text-vinculo-dark">Documentos privados</h2>
+        </div>
+        {!loading && !error && (
+          <span className="text-sm text-slate-500">
+            {documents.length} documento{documents.length === 1 ? "" : "s"}
+          </span>
+        )}
+      </div>
+
+      <p className="mt-3 text-sm leading-6 text-slate-500">
+        Estes arquivos são restritos à conta da ONG. Empresas, visitantes externos e administradores não têm acesso a esta listagem.
+      </p>
+
+      {loading && (
+        <div className="mt-6 rounded-lg border border-slate-200 bg-slate-50 px-4 py-5 text-sm text-slate-500">
+          Carregando documentos...
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-6 rounded-lg border border-red-200 bg-red-50 px-4 py-5 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && documents.length === 0 && (
+        <div className="mt-6 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm text-slate-500">
+          Nenhum documento enviado até o momento.
+        </div>
+      )}
+
+      {!loading && !error && documents.length > 0 && (
+        <div className="mt-6 flex flex-col gap-3">
+          {documents.map((document) => (
+            <div
+              key={document.id}
+              className="flex flex-col gap-4 rounded-lg border border-slate-200 bg-slate-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="grid h-11 w-11 shrink-0 place-items-center rounded-lg bg-vinculo-dark text-white">
+                  <DescriptionOutlinedIcon fontSize="small" />
+                </span>
+                <div className="min-w-0">
+                  <p className="break-words text-sm font-semibold text-vinculo-dark">
+                    {document.title || document.fileName}
+                  </p>
+                  <p className="mt-1 break-words text-xs text-slate-500">
+                    {document.fileName}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    {formatFileSize(document.fileSize)} · Enviado em {formatDate(document.createdAt)}
+                  </p>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 text-sm font-semibold text-vinculo-dark transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+                disabled={downloadingId === document.id}
+                onClick={() => void handleDownload(document.id)}
+              >
+                <DownloadOutlinedIcon fontSize="small" />
+                {downloadingId === document.id ? "Gerando..." : "Baixar"}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </article>
+  )
+}

--- a/frontend/src/pages/OngProfilePage/index.test.tsx
+++ b/frontend/src/pages/OngProfilePage/index.test.tsx
@@ -8,6 +8,9 @@ import type { NpoProfileResponse } from "../../api/npo"
 const mocks = vi.hoisted(() => ({
   useNpoProfile: vi.fn(),
   save: vi.fn(),
+  getAccessTokenSilently: vi.fn(),
+  fetchMyOngDocuments: vi.fn(),
+  getMyOngDocumentDownloadUrl: vi.fn(),
 }))
 
 vi.mock("../../hooks/useNpoProfile", () => ({
@@ -16,12 +19,17 @@ vi.mock("../../hooks/useNpoProfile", () => ({
 
 vi.mock("@auth0/auth0-react", () => ({
   useAuth0: () => ({
-    getAccessTokenSilently: vi.fn(),
+    getAccessTokenSilently: mocks.getAccessTokenSilently,
     isAuthenticated: true,
     loginWithRedirect: vi.fn(),
     logout: vi.fn(),
     user: { "https://vinculohub/roles": ["NPO"] },
   }),
+}))
+
+vi.mock("../../api/document", () => ({
+  fetchMyOngDocuments: mocks.fetchMyOngDocuments,
+  getMyOngDocumentDownloadUrl: mocks.getMyOngDocumentDownloadUrl,
 }))
 
 const ownerProfile: NpoProfileResponse = {
@@ -62,7 +70,36 @@ const ownerProfile: NpoProfileResponse = {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks()
   mocks.save.mockResolvedValue(undefined)
+  mocks.getAccessTokenSilently.mockResolvedValue("fake-token")
+  mocks.fetchMyOngDocuments.mockResolvedValue({
+    content: [
+      {
+        id: 10,
+        npoId: 1,
+        title: "Backlog do Produto - VinculoHub Portal",
+        description: "Documento para teste",
+        fileUrl: "https://bucket/doc.pdf",
+        fileName: "backlog.pdf",
+        fileSize: 176742,
+        mimeType: "application/pdf",
+        createdAt: "2026-05-13T20:20:24",
+        updatedAt: "2026-05-13T20:20:24",
+        deletedAt: null,
+      },
+    ],
+    totalElements: 1,
+    totalPages: 1,
+    number: 0,
+    size: 20,
+  })
+  mocks.getMyOngDocumentDownloadUrl.mockResolvedValue({
+    downloadUrl: "https://signed-url.test/document.pdf",
+    fileName: "backlog.pdf",
+    mimeType: "application/pdf",
+    expiresAt: "2026-05-30T22:11:05Z",
+  })
   mocks.useNpoProfile.mockReturnValue({
     profile: ownerProfile,
     loading: false,
@@ -73,6 +110,7 @@ beforeEach(() => {
   Object.assign(navigator, {
     clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
   })
+  vi.spyOn(window, "open").mockImplementation(() => null)
 })
 
 function renderPage() {
@@ -136,6 +174,31 @@ describe("OngProfilePage — viewerContext OWNER", () => {
   it("exibe card de perfil público para OWNER", () => {
     renderPage()
     expect(screen.getByLabelText("Link do perfil público")).toBeInTheDocument()
+  })
+
+  it("lista documentos privados para OWNER", async () => {
+    renderPage()
+
+    expect(await screen.findByText("Documentos privados")).toBeInTheDocument()
+    expect(screen.getByText("Backlog do Produto - VinculoHub Portal")).toBeInTheDocument()
+    expect(screen.getByText("backlog.pdf")).toBeInTheDocument()
+    expect(mocks.fetchMyOngDocuments).toHaveBeenCalledWith("fake-token")
+  })
+
+  it("gera URL assinada ao baixar documento privado", async () => {
+    renderPage()
+
+    await screen.findByText("Backlog do Produto - VinculoHub Portal")
+    await userEvent.click(screen.getByRole("button", { name: "Baixar" }))
+
+    await waitFor(() => {
+      expect(mocks.getMyOngDocumentDownloadUrl).toHaveBeenCalledWith(10, "fake-token")
+    })
+    expect(window.open).toHaveBeenCalledWith(
+      "https://signed-url.test/document.pdf",
+      "_blank",
+      "noopener,noreferrer",
+    )
   })
 
   it("link público contém o id da ONG", () => {
@@ -220,5 +283,18 @@ describe("OngProfilePage — viewerContext EXTERNAL", () => {
     })
     renderPage()
     expect(screen.queryByLabelText("Link do perfil público")).not.toBeInTheDocument()
+  })
+
+  it("não exibe documentos privados para EXTERNAL", () => {
+    mocks.useNpoProfile.mockReturnValue({
+      profile: { ...ownerProfile, viewerContext: "EXTERNAL" },
+      loading: false,
+      error: null,
+      save: mocks.save,
+      refetch: vi.fn(),
+    })
+    renderPage()
+    expect(screen.queryByText("Documentos privados")).not.toBeInTheDocument()
+    expect(mocks.fetchMyOngDocuments).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/OngProfilePage/index.tsx
+++ b/frontend/src/pages/OngProfilePage/index.tsx
@@ -6,6 +6,7 @@ import { useNpoProfile } from "../../hooks/useNpoProfile"
 import type { NpoAddressData, NpoContactData, NpoInstitutionalData, NpoProfileUpdateRequest, NpoResponsibleData } from "../../api/npo"
 import { OrganizationInfoCard } from "./OrganizationInfoCard"
 import { ProfileHeaderCard } from "./ProfileHeaderCard"
+import { PrivateDocumentsCard } from "./PrivateDocumentsCard"
 import { PublicProfileCard } from "./PublicProfileCard"
 import { ResponsibleCard } from "./ResponsibleCard"
 
@@ -193,7 +194,10 @@ export function OngProfilePage() {
         )}
 
         {editable && (
-          <PublicProfileCard id={profile.institutionalData.id} />
+          <>
+            <PrivateDocumentsCard />
+            <PublicProfileCard id={profile.institutionalData.id} />
+          </>
         )}
       </main>
     </div>

--- a/frontend/src/pages/RoleHomePage/OngDashboardMock.tsx
+++ b/frontend/src/pages/RoleHomePage/OngDashboardMock.tsx
@@ -80,7 +80,7 @@ export function OngDashboardMock({
         token,
       )
 
-      showToast("Documento enviado com sucesso!")
+      showToast("Documento enviado com sucesso!", "success")
       setIsUploadModalOpen(false)
     } catch (error) {
       console.error("Upload Error:", error) 


### PR DESCRIPTION
## Resumo:

Implementa o fluxo privado de documentos da ONG, incluindo download seguro via URL pré-assinada, listagem no perfil da ONG e ajustes de feedback visual no upload.


- Criação do endpoint privado de download:
  - `GET /api/documents/my-ong/{documentId}/download`
  - Disponível apenas para usuários com role `NPO`
  - Valida que o documento pertence à ONG autenticada antes de gerar o link

- Geração de URL pré-assinada no S3:
  - Usa o `fileUrl` já existente no banco
  - Não altera a estrutura do banco de dados
  - Decodifica corretamente chaves S3 com espaços e caracteres especiais

- Nova resposta de download:
  - `downloadUrl`
  - `fileName`
  - `mimeType`
  - `expiresAt`

- Listagem de documentos privados no frontend:
  - Novo card `Documentos privados` no perfil da ONG
  - Cada documento pode ser baixado usando um endpoint
  
- API frontend:
  - `fetchMyOngDocuments`
  - `getMyOngDocumentDownloadUrl`


- Ajustes de UX:
  - Toast de sucesso no upload de documento agora usa severidade `success`, aparecendo em verde

- Docker:
  - `flyway` agora espera o healthcheck do banco antes de executar migrations

