### PR TITLE
feat(vinculos): backend do épico Meus Vínculos (VNC-01..04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,53 @@ Os testes cobrem:
 
 ---
 
+## 📬 API de Vínculos — Swagger e coleção Bruno
+
+A API do épico **Vínculos** (`/api/relationships`) pode ser explorada de duas formas.
+
+### Swagger / OpenAPI (app rodando)
+- UI interativa: **http://localhost:8080/swagger-ui.html**
+- Spec OpenAPI (JSON): **http://localhost:8080/v3/api-docs**
+
+Clique em **Authorize** e cole um JWT (`Bearer`) para chamar os endpoints autenticados. A mesma spec
+pode ser importada no Postman/Insomnia (Import → URL → `/v3/api-docs`).
+
+### Coleção Bruno
+A coleção fica versionada em `backend/docs/api/vinculos/` (arquivos `.bru`, amigáveis ao git) e cobre
+o ciclo completo (criar interesse → aceitar → efetivar → ativo).
+
+**Opção 1 — app desktop ([Bruno](https://www.usebruno.com/)):**
+1. Abra a pasta `backend/docs/api/vinculos` no Bruno.
+2. Selecione o environment **Local** e preencha `bearerToken` com um JWT válido.
+3. Rode as requisições na ordem `01 → 05`.
+
+**Opção 2 — CLI:**
+```bash
+npm i -g @usebruno/cli
+cd backend/docs/api/vinculos
+bru run --env Local --env-var bearerToken=<jwt>
+```
+
+### Como obter um `bearerToken` sem Auth0 (profile dev)
+Existe um stack de desenvolvimento com **auth local** (sem Auth0): ele assina o JWT localmente,
+expõe um emissor de tokens em `/dev/token` e semeia dados de exemplo (Empresa + ONG + Projeto).
+
+```bash
+# sobe Postgres + backend no profile dev (porta 8088)
+docker compose -f docker-compose.dev.yml up --build -d
+
+# emite um token (note o %7C, que é o "|" url-encodado)
+curl "http://localhost:8088/dev/token?sub=dev%7Ccompany&roles=COMPANY"   # empresa
+curl "http://localhost:8088/dev/token?sub=dev%7Cnpo&roles=NPO"           # ONG
+```
+Copie o `access_token` da resposta e use como `bearerToken` no Bruno (ou no `Authorize` do Swagger).
+Para encerrar: `docker compose -f docker-compose.dev.yml down -v`.
+
+> ⚠️ O profile `dev` e o `/dev/token` existem **apenas para desenvolvimento**. Em produção o app roda
+> no profile padrão, que continua validando JWTs reais do Auth0.
+
+---
+
 ## 📊 Cobertura de Testes (JaCoCo)
 O JaCoCo é utilizado para medir a porcentagem do código backend que está sendo validada pelos testes unitários.
 

--- a/backend/docs/api/vinculos/01 - List Relationships (VNC-01).bru
+++ b/backend/docs/api/vinculos/01 - List Relationships (VNC-01).bru
@@ -1,0 +1,25 @@
+meta {
+  name: 01 - List Relationships (VNC-01)
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/api/relationships?status=pending
+  body: none
+  auth: bearer
+}
+
+params:query {
+  status: pending
+}
+
+auth:bearer {
+  token: {{bearerToken}}
+}
+
+docs {
+  Lista os vínculos visíveis (pending, negotiation, active) do ator autenticado.
+  Remova o parâmetro `status` para listar todos. Contatos e flags canRespond/canConfirm
+  vêm preenchidos conforme o status e o papel do ator.
+}

--- a/backend/docs/api/vinculos/02 - Create Interest (VNC-02).bru
+++ b/backend/docs/api/vinculos/02 - Create Interest (VNC-02).bru
@@ -1,0 +1,28 @@
+meta {
+  name: 02 - Create Interest (VNC-02)
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/relationships
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{bearerToken}}
+}
+
+body:json {
+  {
+    "projectId": 1,
+    "companyId": null
+  }
+}
+
+docs {
+  1º aperto de mão (envio). Empresa: envie apenas `projectId` (companyId é ignorado).
+  ONG: `projectId` deve ser um projeto da própria ONG e `companyId` é a empresa alvo (obrigatório).
+  Resposta: 201 Created. Status do vínculo passa a 'pending'.
+}

--- a/backend/docs/api/vinculos/03 - Accept (VNC-03).bru
+++ b/backend/docs/api/vinculos/03 - Accept (VNC-03).bru
@@ -1,0 +1,20 @@
+meta {
+  name: 03 - Accept (VNC-03)
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/relationships/1/1/accept
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{bearerToken}}
+}
+
+docs {
+  1º aperto de mão (resposta). Apenas o receptor pode aceitar. Path: /{companyId}/{projectId}/accept.
+  Status passa a 'negotiation' e os contatos de ambas as partes ficam visíveis na listagem.
+}

--- a/backend/docs/api/vinculos/04 - Reject (VNC-03).bru
+++ b/backend/docs/api/vinculos/04 - Reject (VNC-03).bru
@@ -1,0 +1,20 @@
+meta {
+  name: 04 - Reject (VNC-03)
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/relationships/1/1/reject
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{bearerToken}}
+}
+
+docs {
+  1º aperto de mão (resposta). Apenas o receptor pode recusar. Path: /{companyId}/{projectId}/reject.
+  O vínculo é encerrado (status 'inactive') e some da listagem de vínculos visíveis.
+}

--- a/backend/docs/api/vinculos/05 - Confirm Partnership (VNC-04).bru
+++ b/backend/docs/api/vinculos/05 - Confirm Partnership (VNC-04).bru
@@ -1,0 +1,21 @@
+meta {
+  name: 05 - Confirm Partnership (VNC-04)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/relationships/1/1/confirm
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{bearerToken}}
+}
+
+docs {
+  2º aperto de mão. Cada parte chama este endpoint uma vez. Path: /{companyId}/{projectId}/confirm.
+  Após a confirmação das DUAS partes o status passa a 'active' e o vínculo alimenta o
+  Dashboard de Impacto ESG. Antes disso permanece em 'negotiation'.
+}

--- a/backend/docs/api/vinculos/README.md
+++ b/backend/docs/api/vinculos/README.md
@@ -1,0 +1,38 @@
+# Vínculos — API docs
+
+Backend do épico **Vínculos** (VNC-01..04). Duas formas de explorar a API:
+
+## Swagger / OpenAPI
+Com a aplicação rodando (`./mvnw spring-boot:run`):
+- UI interativa: http://localhost:8080/swagger-ui.html
+- Spec OpenAPI (JSON): http://localhost:8080/v3/api-docs
+
+Clique em **Authorize** e cole um JWT (Bearer) para chamar os endpoints autenticados.
+A spec também pode ser importada no Postman/Insomnia (Import → URL → `/v3/api-docs`).
+
+## Bruno
+Esta pasta é uma coleção [Bruno](https://www.usebruno.com/) (arquivos `.bru`, versionáveis em git).
+
+**App desktop:**
+1. Abra a pasta `docs/api/vinculos` no Bruno.
+2. Selecione o environment **Local** e preencha `bearerToken` com um JWT válido.
+3. Execute as requisições na ordem (01 → 05) para percorrer o ciclo completo:
+   criar interesse → aceitar → ambas as partes efetivam → status `active`.
+
+**CLI:**
+```bash
+npm i -g @usebruno/cli
+bru run --env Local --env-var bearerToken=<jwt>   # rode dentro de docs/api/vinculos
+```
+
+Ajuste `companyId`/`projectId` nas URLs e no corpo conforme os dados do seu ambiente.
+
+## Como obter um `bearerToken` (sem Auth0)
+Suba o stack de desenvolvimento (auth local) na raiz do projeto e emita um token:
+```bash
+docker compose -f docker-compose.dev.yml up --build -d
+curl "http://localhost:8088/dev/token?sub=dev%7Ccompany&roles=COMPANY"   # empresa (seed: company/project id 1)
+curl "http://localhost:8088/dev/token?sub=dev%7Cnpo&roles=NPO"           # ONG
+```
+Copie o `access_token` da resposta para o `bearerToken`. O `%7C` é o `|` url-encodado (sem isso o
+Tomcat responde 400). O profile `dev` semeia uma Empresa, uma ONG e um Projeto automaticamente.

--- a/backend/docs/api/vinculos/bruno.json
+++ b/backend/docs/api/vinculos/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "VinculoHub - Vínculos",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/backend/docs/api/vinculos/environments/Local.bru
+++ b/backend/docs/api/vinculos/environments/Local.bru
@@ -1,0 +1,4 @@
+vars {
+  baseUrl: http://localhost:8080
+  bearerToken:
+}

--- a/backend/src/main/java/com/vinculohub/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/OpenApiConfig.java
@@ -1,0 +1,39 @@
+/* (C)2026 */
+package com.vinculohub.backend.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI metadata and a bearer-JWT security scheme so the "Authorize" button works in Swagger UI
+ * ({@code /swagger-ui.html}); the spec is served at {@code /v3/api-docs}.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BEARER_SCHEME = "bearerAuth";
+
+    @Bean
+    public OpenAPI vinculoHubOpenAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title("VinculoHub Portal API")
+                                .description("API do VinculoHubPortal — inclui o épico Vínculos.")
+                                .version("v1"))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER_SCHEME))
+                .components(
+                        new Components()
+                                .addSecuritySchemes(
+                                        BEARER_SCHEME,
+                                        new SecurityScheme()
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("bearer")
+                                                .bearerFormat("JWT")));
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/SecurityConfig.java
@@ -55,6 +55,15 @@ public class SecurityConfig {
                                         .permitAll()
                                         .requestMatchers("/public/**")
                                         .permitAll()
+                                        .requestMatchers(
+                                                "/v3/api-docs/**",
+                                                "/swagger-ui/**",
+                                                "/swagger-ui.html")
+                                        .permitAll()
+                                        // Apenas profile dev: o controller /dev/** só é
+                                        // registrado em dev; em produção a rota não existe.
+                                        .requestMatchers("/dev/**")
+                                        .permitAll()
                                         .requestMatchers("/cep/**", "/cnpj/**")
                                         .permitAll()
                                         .requestMatchers(HttpMethod.GET, "/api/editais")

--- a/backend/src/main/java/com/vinculohub/backend/config/dev/DevDataSeeder.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/dev/DevDataSeeder.java
@@ -1,0 +1,100 @@
+/* (C)2026 */
+package com.vinculohub.backend.config.dev;
+
+import com.vinculohub.backend.model.Company;
+import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.model.User;
+import com.vinculohub.backend.model.enums.NpoSize;
+import com.vinculohub.backend.model.enums.UserType;
+import com.vinculohub.backend.repository.CompanyRepository;
+import com.vinculohub.backend.repository.NpoRepository;
+import com.vinculohub.backend.repository.ProjectRepository;
+import com.vinculohub.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Seed idempotente para o profile {@code dev}: garante uma Empresa (sub {@code dev|company}) e uma
+ * ONG (sub {@code dev|npo}) com um Projeto, casando com os {@code sub} emitidos pelo
+ * {@link com.vinculohub.backend.controller.dev.DevTokenController}, para que o fluxo de vínculos
+ * possa ser exercitado via curl logo após subir o app.
+ */
+@Slf4j
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+public class DevDataSeeder implements CommandLineRunner {
+
+    private static final String COMPANY_SUB = "dev|company";
+    private static final String NPO_SUB = "dev|npo";
+
+    private final UserRepository userRepository;
+    private final CompanyRepository companyRepository;
+    private final NpoRepository npoRepository;
+    private final ProjectRepository projectRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        if (userRepository.findByAuth0Id(COMPANY_SUB).isEmpty()) {
+            User companyUser =
+                    userRepository.save(
+                            User.builder()
+                                    .name("Empresa Dev")
+                                    .email("empresa.dev@vinculohub.local")
+                                    .auth0Id(COMPANY_SUB)
+                                    .userType(UserType.company)
+                                    .build());
+            Company company = new Company();
+            company.setSocialName("Empresa Dev S.A.");
+            company.setLegalName("Empresa Desenvolvimento Ltda");
+            company.setPhone("(11) 1111-1111");
+            company.setUser(companyUser);
+            company = companyRepository.save(company);
+            log.info(
+                    "[DEV SEED] Empresa criada | companyId={} sub={}",
+                    company.getId(),
+                    COMPANY_SUB);
+        }
+
+        if (userRepository.findByAuth0Id(NPO_SUB).isEmpty()) {
+            User npoUser =
+                    userRepository.save(
+                            User.builder()
+                                    .name("ONG Dev")
+                                    .email("ong.dev@vinculohub.local")
+                                    .auth0Id(NPO_SUB)
+                                    .userType(UserType.npo)
+                                    .build());
+            Npo npo =
+                    npoRepository.save(
+                            Npo.builder()
+                                    .name("ONG Dev")
+                                    .npoSize(NpoSize.small)
+                                    .phone("(11) 2222-2222")
+                                    .userId(npoUser.getId())
+                                    .build());
+            Project project =
+                    projectRepository.save(
+                            Project.builder()
+                                    .npo(npo)
+                                    .title("Projeto Dev")
+                                    .description("Projeto semeado para testes locais")
+                                    .build());
+            log.info(
+                    "[DEV SEED] ONG criada | npoId={} projectId={} sub={}",
+                    npo.getId(),
+                    project.getId(),
+                    NPO_SUB);
+        }
+
+        log.info(
+                "[DEV SEED] pronto. Tokens: GET /dev/token?sub=dev|company&roles=COMPANY  e "
+                        + "GET /dev/token?sub=dev|npo&roles=NPO");
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/config/dev/DevJwtConfig.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/dev/DevJwtConfig.java
@@ -1,0 +1,43 @@
+/* (C)2026 */
+package com.vinculohub.backend.config.dev;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+/**
+ * Auth LOCAL para o profile {@code dev}: um par decoder/encoder HS256 com um segredo de
+ * desenvolvimento, substituindo o Auth0. Por fornecer um {@link JwtDecoder}, a auto-config do
+ * resource server (que buscaria o JWKS do Auth0) recua. NUNCA habilitar em produção — o profile
+ * default continua validando JWTs reais do Auth0.
+ */
+@Configuration
+@Profile("dev")
+public class DevJwtConfig {
+
+    private final SecretKey secretKey;
+
+    public DevJwtConfig(@Value("${app.dev.jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    @Bean
+    public JwtDecoder devJwtDecoder() {
+        return NimbusJwtDecoder.withSecretKey(secretKey).macAlgorithm(MacAlgorithm.HS256).build();
+    }
+
+    @Bean
+    public JwtEncoder devJwtEncoder() {
+        return new NimbusJwtEncoder(new ImmutableSecret<>(secretKey));
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/controller/RelationshipController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/RelationshipController.java
@@ -1,0 +1,127 @@
+/* (C)2026 */
+package com.vinculohub.backend.controller;
+
+import com.vinculohub.backend.dto.CreateRelationshipRequest;
+import com.vinculohub.backend.dto.RelationshipListItemResponse;
+import com.vinculohub.backend.model.enums.RelationshipStatus;
+import com.vinculohub.backend.service.RelationshipService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * "Meus Vínculos" — central management of partnerships between Companies and NPOs (Épico Vínculos,
+ * VNC-01..04). The authenticated actor (Company or NPO) is resolved server-side; participant and
+ * receptor checks live in {@link RelationshipService}.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/relationships")
+@RequiredArgsConstructor
+@PreAuthorize("isAuthenticated()")
+@Tag(name = "Vínculos", description = "Gestão de vínculos (parcerias) entre Empresas e ONGs")
+public class RelationshipController {
+
+    private final RelationshipService relationshipService;
+
+    @GetMapping
+    @Operation(
+            summary = "Listar Meus Vínculos (VNC-01)",
+            description =
+                    "Lista os vínculos visíveis (pendentes, em negociação e ativos) do ator"
+                            + " autenticado, opcionalmente filtrando por status.")
+    public ResponseEntity<List<RelationshipListItemResponse>> listMyRelationships(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam(required = false) RelationshipStatus status) {
+        log.info("GET /api/relationships | sub={} status={}", jwt.getSubject(), status);
+        return ResponseEntity.ok(relationshipService.listMyRelationships(jwt.getSubject(), status));
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "Iniciar vínculo — 1º aperto de mão, envio (VNC-02)",
+            description =
+                    "Cria um vínculo com status 'pending' atrelado a um projeto. Empresa: informa"
+                        + " apenas o projeto. ONG: informa um projeto próprio + a empresa alvo.")
+    public ResponseEntity<Void> createRelationship(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody CreateRelationshipRequest request) {
+        log.info(
+                "POST /api/relationships | sub={} projectId={} companyId={}",
+                jwt.getSubject(),
+                request.projectId(),
+                request.companyId());
+        relationshipService.createRelationship(jwt.getSubject(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/{companyId}/{projectId}/accept")
+    @Operation(
+            summary = "Aceitar contato — 1º aperto de mão, resposta (VNC-03)",
+            description =
+                    "Receptor aceita o interesse: status passa a 'negotiation' e os contatos de"
+                            + " ambas as partes são revelados mutuamente.")
+    public ResponseEntity<Void> acceptRelationship(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer companyId,
+            @PathVariable Long projectId) {
+        log.info(
+                "POST /api/relationships/{}/{}/accept | sub={}",
+                companyId,
+                projectId,
+                jwt.getSubject());
+        relationshipService.acceptRelationship(jwt.getSubject(), companyId, projectId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{companyId}/{projectId}/reject")
+    @Operation(
+            summary = "Recusar — 1º aperto de mão, resposta (VNC-03)",
+            description = "Receptor recusa o interesse: o vínculo é encerrado (status 'inactive').")
+    public ResponseEntity<Void> rejectRelationship(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer companyId,
+            @PathVariable Long projectId) {
+        log.info(
+                "POST /api/relationships/{}/{}/reject | sub={}",
+                companyId,
+                projectId,
+                jwt.getSubject());
+        relationshipService.rejectRelationship(jwt.getSubject(), companyId, projectId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{companyId}/{projectId}/confirm")
+    @Operation(
+            summary = "Efetivar parceria — 2º aperto de mão (VNC-04)",
+            description =
+                    "Registra a confirmação do ator. Quando ambas as partes confirmam, o status"
+                            + " passa a 'active' e o vínculo alimenta o Dashboard de Impacto ESG.")
+    public ResponseEntity<Void> confirmRelationship(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer companyId,
+            @PathVariable Long projectId) {
+        log.info(
+                "POST /api/relationships/{}/{}/confirm | sub={}",
+                companyId,
+                projectId,
+                jwt.getSubject());
+        relationshipService.confirmRelationship(jwt.getSubject(), companyId, projectId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/controller/dev/DevTokenController.java
+++ b/backend/src/main/java/com/vinculohub/backend/controller/dev/DevTokenController.java
@@ -1,0 +1,75 @@
+/* (C)2026 */
+package com.vinculohub.backend.controller.dev;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Emissor de tokens APENAS para o profile {@code dev}. Gera um JWT HS256 (assinado pelo segredo
+ * local do {@link com.vinculohub.backend.config.dev.DevJwtConfig}) com o {@code sub} e as roles
+ * desejadas, para testar os endpoints autenticados via curl sem depender do Auth0. Em produção esta
+ * rota não existe (o controller só é registrado no profile dev).
+ */
+@RestController
+@Profile("dev")
+@RequestMapping("/dev")
+@RequiredArgsConstructor
+@Tag(name = "Dev", description = "Utilitários de desenvolvimento (somente profile dev)")
+public class DevTokenController {
+
+    private final JwtEncoder jwtEncoder;
+
+    @Value("${app.auth0.roles-claim}")
+    private String rolesClaim;
+
+    @GetMapping("/token")
+    @Operation(
+            summary = "Emite um JWT de desenvolvimento",
+            description =
+                    "Gera um token Bearer assinado localmente (HS256) com o sub e as roles"
+                            + " informados. Ex.: /dev/token?sub=dev|company&roles=COMPANY")
+    public ResponseEntity<Map<String, Object>> token(
+            @RequestParam(defaultValue = "dev|company") String sub,
+            @RequestParam(defaultValue = "COMPANY") List<String> roles) {
+        Instant now = Instant.now();
+        Duration ttl = Duration.ofHours(12);
+
+        JwtClaimsSet claims =
+                JwtClaimsSet.builder()
+                        .subject(sub)
+                        .issuer("http://dev-local/")
+                        .audience(List.of("dev-local"))
+                        .issuedAt(now)
+                        .expiresAt(now.plus(ttl))
+                        .claim(rolesClaim, roles)
+                        .build();
+
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).build();
+        String token = jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+
+        return ResponseEntity.ok(
+                Map.of(
+                        "access_token", token,
+                        "token_type", "Bearer",
+                        "sub", sub,
+                        "roles", roles,
+                        "expires_in", ttl.toSeconds()));
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/dto/CreateRelationshipRequest.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/CreateRelationshipRequest.java
@@ -1,0 +1,16 @@
+/* (C)2026 */
+package com.vinculohub.backend.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request to start a vínculo (1st handshake — VNC-02). The relationship is always tied to a
+ * specific {@code projectId}.
+ *
+ * <p>When the caller is a <b>Company</b> (interest on a project page), {@code companyId} is ignored
+ * and the caller's own company is used. When the caller is an <b>NPO</b> ("Propor Parceria" on a
+ * company profile), {@code projectId} must be one of the NPO's own projects and {@code companyId}
+ * is the targeted company (required).
+ */
+public record CreateRelationshipRequest(
+        @NotNull(message = "projectId é obrigatório") Long projectId, Integer companyId) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/RelationshipListItemResponse.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/RelationshipListItemResponse.java
@@ -3,9 +3,21 @@ package com.vinculohub.backend.dto;
 
 import com.vinculohub.backend.model.enums.RelationshipStatus;
 
+/**
+ * One row of the "Meus Vínculos" panel (VNC-01).
+ *
+ * <p>{@code partnerContactEmail}/{@code partnerContactPhone} are only populated once the
+ * relationship reaches {@code negotiation} or {@code active} (1st handshake accepted — VNC-03);
+ * they are {@code null} while {@code pending}. {@code canRespond} and {@code canConfirm} tell the
+ * caller which actions it may take given its role in this specific relationship.
+ */
 public record RelationshipListItemResponse(
         Long projectId,
         String projectName,
         Integer partnerInstitutionId,
         String partnerInstitutionName,
-        RelationshipStatus status) {}
+        RelationshipStatus status,
+        String partnerContactEmail,
+        String partnerContactPhone,
+        boolean canRespond,
+        boolean canConfirm) {}

--- a/backend/src/main/java/com/vinculohub/backend/dto/RelationshipListItemResponse.java
+++ b/backend/src/main/java/com/vinculohub/backend/dto/RelationshipListItemResponse.java
@@ -1,0 +1,11 @@
+/* (C)2026 */
+package com.vinculohub.backend.dto;
+
+import com.vinculohub.backend.model.enums.RelationshipStatus;
+
+public record RelationshipListItemResponse(
+        Long projectId,
+        String projectName,
+        Integer partnerInstitutionId,
+        String partnerInstitutionName,
+        RelationshipStatus status) {}

--- a/backend/src/main/java/com/vinculohub/backend/model/CompanyProject.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/CompanyProject.java
@@ -1,6 +1,7 @@
 /* (C)2026 */
 package com.vinculohub.backend.model;
 
+import com.vinculohub.backend.model.enums.InitiatorType;
 import com.vinculohub.backend.model.enums.RelationshipStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
@@ -51,6 +52,24 @@ public class CompanyProject {
     @Column(name = "status", columnDefinition = "relationship_status")
     @Builder.Default
     private RelationshipStatus status = RelationshipStatus.pending;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(name = "initiator_type", columnDefinition = "initiator_type")
+    @Builder.Default
+    private InitiatorType initiatorType = InitiatorType.company;
+
+    @Column(name = "company_confirmed_at")
+    private LocalDateTime companyConfirmedAt;
+
+    @Column(name = "npo_confirmed_at")
+    private LocalDateTime npoConfirmedAt;
+
+    @Column(name = "responded_at")
+    private LocalDateTime respondedAt;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/backend/src/main/java/com/vinculohub/backend/model/enums/InitiatorType.java
+++ b/backend/src/main/java/com/vinculohub/backend/model/enums/InitiatorType.java
@@ -1,0 +1,7 @@
+/* (C)2026 */
+package com.vinculohub.backend.model.enums;
+
+public enum InitiatorType {
+    company,
+    npo
+}

--- a/backend/src/main/java/com/vinculohub/backend/repository/CompanyProjectRepository.java
+++ b/backend/src/main/java/com/vinculohub/backend/repository/CompanyProjectRepository.java
@@ -3,7 +3,10 @@ package com.vinculohub.backend.repository;
 
 import com.vinculohub.backend.model.CompanyProject;
 import com.vinculohub.backend.model.CompanyProjectId;
+import com.vinculohub.backend.model.enums.RelationshipStatus;
 import com.vinculohub.backend.repository.projection.CompanySupportedProjectsSummaryProjection;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +14,50 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CompanyProjectRepository extends JpaRepository<CompanyProject, CompanyProjectId> {
+
+    List<RelationshipStatus> VISIBLE_RELATIONSHIP_STATUSES =
+            List.of(
+                    RelationshipStatus.pending,
+                    RelationshipStatus.negotiation,
+                    RelationshipStatus.active);
+
+    default List<CompanyProject> findVisibleRelationshipsByCompanyId(Integer companyId) {
+        return findRelationshipsByCompanyIdAndStatusIn(companyId, VISIBLE_RELATIONSHIP_STATUSES);
+    }
+
+    default List<CompanyProject> findVisibleRelationshipsByNpoId(Integer npoId) {
+        return findRelationshipsByNpoIdAndStatusIn(npoId, VISIBLE_RELATIONSHIP_STATUSES);
+    }
+
+    @Query(
+            """
+            SELECT cp
+            FROM CompanyProject cp
+            JOIN FETCH cp.company c
+            JOIN FETCH cp.project p
+            JOIN FETCH p.npo n
+            WHERE c.id = :companyId
+              AND cp.status IN :statuses
+            ORDER BY cp.updatedAt DESC, cp.createdAt DESC
+            """)
+    List<CompanyProject> findRelationshipsByCompanyIdAndStatusIn(
+            @Param("companyId") Integer companyId,
+            @Param("statuses") Collection<RelationshipStatus> statuses);
+
+    @Query(
+            """
+            SELECT cp
+            FROM CompanyProject cp
+            JOIN FETCH cp.company c
+            JOIN FETCH cp.project p
+            JOIN FETCH p.npo n
+            WHERE n.id = :npoId
+              AND cp.status IN :statuses
+            ORDER BY cp.updatedAt DESC, cp.createdAt DESC
+            """)
+    List<CompanyProject> findRelationshipsByNpoIdAndStatusIn(
+            @Param("npoId") Integer npoId,
+            @Param("statuses") Collection<RelationshipStatus> statuses);
 
     @Query(
             value =

--- a/backend/src/main/java/com/vinculohub/backend/repository/CompanyProjectRepository.java
+++ b/backend/src/main/java/com/vinculohub/backend/repository/CompanyProjectRepository.java
@@ -7,6 +7,7 @@ import com.vinculohub.backend.model.enums.RelationshipStatus;
 import com.vinculohub.backend.repository.projection.CompanySupportedProjectsSummaryProjection;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -34,8 +35,10 @@ public interface CompanyProjectRepository extends JpaRepository<CompanyProject, 
             SELECT cp
             FROM CompanyProject cp
             JOIN FETCH cp.company c
+            LEFT JOIN FETCH c.user
             JOIN FETCH cp.project p
             JOIN FETCH p.npo n
+            LEFT JOIN FETCH n.npoUser
             WHERE c.id = :companyId
               AND cp.status IN :statuses
             ORDER BY cp.updatedAt DESC, cp.createdAt DESC
@@ -49,8 +52,10 @@ public interface CompanyProjectRepository extends JpaRepository<CompanyProject, 
             SELECT cp
             FROM CompanyProject cp
             JOIN FETCH cp.company c
+            LEFT JOIN FETCH c.user
             JOIN FETCH cp.project p
             JOIN FETCH p.npo n
+            LEFT JOIN FETCH n.npoUser
             WHERE n.id = :npoId
               AND cp.status IN :statuses
             ORDER BY cp.updatedAt DESC, cp.createdAt DESC
@@ -58,6 +63,21 @@ public interface CompanyProjectRepository extends JpaRepository<CompanyProject, 
     List<CompanyProject> findRelationshipsByNpoIdAndStatusIn(
             @Param("npoId") Integer npoId,
             @Param("statuses") Collection<RelationshipStatus> statuses);
+
+    @Query(
+            """
+            SELECT cp
+            FROM CompanyProject cp
+            JOIN FETCH cp.company c
+            LEFT JOIN FETCH c.user
+            JOIN FETCH cp.project p
+            JOIN FETCH p.npo n
+            LEFT JOIN FETCH n.npoUser
+            WHERE c.id = :companyId
+              AND p.id = :projectId
+            """)
+    Optional<CompanyProject> findByIdWithGraph(
+            @Param("companyId") Integer companyId, @Param("projectId") Long projectId);
 
     @Query(
             value =

--- a/backend/src/main/java/com/vinculohub/backend/service/RelationshipService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/RelationshipService.java
@@ -1,0 +1,119 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import com.vinculohub.backend.dto.RelationshipListItemResponse;
+import com.vinculohub.backend.exception.BadRequestException;
+import com.vinculohub.backend.exception.NotFoundException;
+import com.vinculohub.backend.exception.UserNotFoundException;
+import com.vinculohub.backend.model.Company;
+import com.vinculohub.backend.model.CompanyProject;
+import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.model.User;
+import com.vinculohub.backend.model.enums.RelationshipStatus;
+import com.vinculohub.backend.repository.CompanyProjectRepository;
+import com.vinculohub.backend.repository.CompanyRepository;
+import com.vinculohub.backend.repository.NpoRepository;
+import com.vinculohub.backend.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RelationshipService {
+
+    private final UserRepository userRepository;
+    private final CompanyRepository companyRepository;
+    private final NpoRepository npoRepository;
+    private final CompanyProjectRepository companyProjectRepository;
+
+    @Transactional(readOnly = true)
+    public List<RelationshipListItemResponse> listMyRelationships(
+            String auth0Id, RelationshipStatus status) {
+        if (auth0Id == null || auth0Id.isBlank()) {
+            throw new BadRequestException("Não foi possível identificar o usuário autenticado.");
+        }
+
+        validateStatus(status);
+
+        User user = userRepository.findByAuth0Id(auth0Id).orElseThrow(UserNotFoundException::new);
+
+        return companyRepository
+                .findByUserId(user.getId())
+                .map(company -> listCompanyRelationships(company, status))
+                .orElseGet(() -> listNpoRelationships(user.getId(), status));
+    }
+
+    private void validateStatus(RelationshipStatus status) {
+        if (status != null
+                && !CompanyProjectRepository.VISIBLE_RELATIONSHIP_STATUSES.contains(status)) {
+            throw new BadRequestException(
+                    "Status inválido para Meus Vínculos.");
+        }
+    }
+
+    private List<RelationshipListItemResponse> listCompanyRelationships(
+            Company company, RelationshipStatus status) {
+        List<CompanyProject> relationships =
+                status == null
+                        ? companyProjectRepository.findVisibleRelationshipsByCompanyId(
+                                company.getId())
+                        : companyProjectRepository.findRelationshipsByCompanyIdAndStatusIn(
+                                company.getId(), List.of(status));
+
+        return relationships.stream().map(this::toCompanyResponse).toList();
+    }
+
+    private List<RelationshipListItemResponse> listNpoRelationships(
+            Integer userId, RelationshipStatus status) {
+        Npo npo =
+                npoRepository
+                        .findByUserId(userId)
+                        .orElseThrow(
+                                () ->
+                                        new NotFoundException(
+                                                "Perfil de empresa ou ONG não encontrado"));
+
+        List<CompanyProject> relationships =
+                status == null
+                        ? companyProjectRepository.findVisibleRelationshipsByNpoId(npo.getId())
+                        : companyProjectRepository.findRelationshipsByNpoIdAndStatusIn(
+                                npo.getId(), List.of(status));
+
+        return relationships.stream().map(this::toNpoResponse).toList();
+    }
+
+    private RelationshipListItemResponse toCompanyResponse(CompanyProject relationship) {
+        Project project = relationship.getProject();
+        Npo partner = project.getNpo();
+
+        return new RelationshipListItemResponse(
+                project.getId(),
+                project.getTitle(),
+                partner.getId(),
+                partner.getName(),
+                relationship.getStatus());
+    }
+
+    private RelationshipListItemResponse toNpoResponse(CompanyProject relationship) {
+        Project project = relationship.getProject();
+        Company partner = relationship.getCompany();
+
+        return new RelationshipListItemResponse(
+                project.getId(),
+                project.getTitle(),
+                partner.getId(),
+                firstPresent(partner.getSocialName(), partner.getLegalName()),
+                relationship.getStatus());
+    }
+
+    private String firstPresent(String first, String second) {
+        if (first != null && !first.isBlank()) {
+            return first;
+        }
+
+        return second;
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/RelationshipService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/RelationshipService.java
@@ -1,49 +1,317 @@
 /* (C)2026 */
 package com.vinculohub.backend.service;
 
+import com.vinculohub.backend.dto.CreateRelationshipRequest;
 import com.vinculohub.backend.dto.RelationshipListItemResponse;
 import com.vinculohub.backend.exception.BadRequestException;
+import com.vinculohub.backend.exception.ForbiddenException;
 import com.vinculohub.backend.exception.NotFoundException;
 import com.vinculohub.backend.exception.UserNotFoundException;
 import com.vinculohub.backend.model.Company;
 import com.vinculohub.backend.model.CompanyProject;
+import com.vinculohub.backend.model.CompanyProjectId;
 import com.vinculohub.backend.model.Npo;
 import com.vinculohub.backend.model.Project;
 import com.vinculohub.backend.model.User;
+import com.vinculohub.backend.model.enums.InitiatorType;
+import com.vinculohub.backend.model.enums.ProjectStatus;
 import com.vinculohub.backend.model.enums.RelationshipStatus;
 import com.vinculohub.backend.repository.CompanyProjectRepository;
 import com.vinculohub.backend.repository.CompanyRepository;
 import com.vinculohub.backend.repository.NpoRepository;
+import com.vinculohub.backend.repository.ProjectRepository;
 import com.vinculohub.backend.repository.UserRepository;
+import com.vinculohub.backend.service.notification.NotificationService;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Backend for the "Vínculos" epic (VNC-01..04): listing relationships, the 1st handshake (interest
+ * + accept/reject with contact reveal) and the 2nd handshake (bilateral confirmation that activates
+ * the partnership). A relationship is always tied to a specific {@link Project}; the actor (Company
+ * or NPO) is resolved from the authenticated user, since companies have no dedicated role.
+ */
 @Service
 @RequiredArgsConstructor
 public class RelationshipService {
 
+    private static final List<RelationshipStatus> CONTACT_VISIBLE_STATUSES =
+            List.of(RelationshipStatus.negotiation, RelationshipStatus.active);
+
     private final UserRepository userRepository;
     private final CompanyRepository companyRepository;
     private final NpoRepository npoRepository;
+    private final ProjectRepository projectRepository;
     private final CompanyProjectRepository companyProjectRepository;
+    private final NotificationService notificationService;
+
+    private enum ActorRole {
+        COMPANY,
+        NPO
+    }
+
+    private record ResolvedActor(ActorRole role, Company company, Npo npo) {
+        boolean isCompany() {
+            return role == ActorRole.COMPANY;
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // VNC-01 — list
+    // ----------------------------------------------------------------------------------------
 
     @Transactional(readOnly = true)
     public List<RelationshipListItemResponse> listMyRelationships(
             String auth0Id, RelationshipStatus status) {
+        validateStatus(status);
+        ResolvedActor actor = resolveActor(auth0Id);
+
+        if (actor.isCompany()) {
+            Integer companyId = actor.company().getId();
+            List<CompanyProject> relationships =
+                    status == null
+                            ? companyProjectRepository.findVisibleRelationshipsByCompanyId(
+                                    companyId)
+                            : companyProjectRepository.findRelationshipsByCompanyIdAndStatusIn(
+                                    companyId, List.of(status));
+            return relationships.stream().map(this::toCompanyViewerResponse).toList();
+        }
+
+        Integer npoId = actor.npo().getId();
+        List<CompanyProject> relationships =
+                status == null
+                        ? companyProjectRepository.findVisibleRelationshipsByNpoId(npoId)
+                        : companyProjectRepository.findRelationshipsByNpoIdAndStatusIn(
+                                npoId, List.of(status));
+        return relationships.stream().map(this::toNpoViewerResponse).toList();
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // VNC-02 — initiate (1st handshake, send)
+    // ----------------------------------------------------------------------------------------
+
+    @Transactional
+    public void createRelationship(String auth0Id, CreateRelationshipRequest request) {
+        if (request == null || request.projectId() == null) {
+            throw new BadRequestException("projectId é obrigatório.");
+        }
+        ResolvedActor actor = resolveActor(auth0Id);
+
+        Project project =
+                projectRepository
+                        .findById(request.projectId())
+                        .orElseThrow(() -> new NotFoundException("Projeto não encontrado."));
+
+        if (project.getStatus() != ProjectStatus.ACTIVE) {
+            throw new BadRequestException("Só é possível iniciar vínculo em um projeto ativo.");
+        }
+
+        Company company;
+        InitiatorType initiatorType;
+        if (actor.isCompany()) {
+            company = actor.company();
+            initiatorType = InitiatorType.company;
+        } else {
+            Npo npo = actor.npo();
+            if (!npo.getId().equals(project.getNpo().getId())) {
+                throw new BadRequestException("O projeto selecionado não pertence à sua ONG.");
+            }
+            if (request.companyId() == null) {
+                throw new BadRequestException(
+                        "companyId é obrigatório quando a ONG inicia o vínculo.");
+            }
+            company =
+                    companyRepository
+                            .findById(request.companyId())
+                            .orElseThrow(() -> new NotFoundException("Empresa não encontrada."));
+            initiatorType = InitiatorType.npo;
+        }
+
+        CompanyProject relationship =
+                companyProjectRepository
+                        .findByIdWithGraph(company.getId(), project.getId())
+                        .orElse(null);
+
+        if (relationship != null
+                && CompanyProjectRepository.VISIBLE_RELATIONSHIP_STATUSES.contains(
+                        relationship.getStatus())) {
+            throw new BadRequestException("Já existe um vínculo em andamento para este projeto.");
+        }
+
+        if (relationship == null) {
+            relationship =
+                    CompanyProject.builder()
+                            .id(new CompanyProjectId(company.getId(), project.getId()))
+                            .company(company)
+                            .project(project)
+                            .build();
+        }
+        relationship.setStatus(RelationshipStatus.pending);
+        relationship.setInitiatorType(initiatorType);
+        relationship.setRespondedAt(null);
+        relationship.setCompanyConfirmedAt(null);
+        relationship.setNpoConfirmedAt(null);
+        companyProjectRepository.save(relationship);
+
+        // Notify the receptor (the party that did NOT initiate).
+        Npo npo = project.getNpo();
+        if (initiatorType == InitiatorType.company) {
+            notificationService.interestReceived(
+                    npoEmail(npo), project.getTitle(), companyName(company));
+        } else {
+            notificationService.interestReceived(
+                    companyEmail(company), project.getTitle(), npoName(npo));
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // VNC-03 — respond (1st handshake, accept/reject)
+    // ----------------------------------------------------------------------------------------
+
+    @Transactional
+    public void acceptRelationship(String auth0Id, Integer companyId, Long projectId) {
+        respond(auth0Id, companyId, projectId, true);
+    }
+
+    @Transactional
+    public void rejectRelationship(String auth0Id, Integer companyId, Long projectId) {
+        respond(auth0Id, companyId, projectId, false);
+    }
+
+    private void respond(String auth0Id, Integer companyId, Long projectId, boolean accept) {
+        ResolvedActor actor = resolveActor(auth0Id);
+        CompanyProject relationship = loadParticipantRelationship(actor, companyId, projectId);
+
+        if (relationship.getStatus() != RelationshipStatus.pending) {
+            throw new BadRequestException("Este vínculo não está pendente de resposta.");
+        }
+        requireReceptor(actor, relationship);
+
+        Company company = relationship.getCompany();
+        Npo npo = relationship.getProject().getNpo();
+        String projectName = relationship.getProject().getTitle();
+        boolean companyInitiated = relationship.getInitiatorType() == InitiatorType.company;
+
+        relationship.setRespondedAt(LocalDateTime.now());
+        relationship.setStatus(
+                accept ? RelationshipStatus.negotiation : RelationshipStatus.inactive);
+        companyProjectRepository.save(relationship);
+
+        // Notify the initiator.
+        String initiatorEmail = companyInitiated ? companyEmail(company) : npoEmail(npo);
+        String partnerName = companyInitiated ? npoName(npo) : companyName(company);
+        if (accept) {
+            notificationService.interestAccepted(initiatorEmail, projectName, partnerName);
+        } else {
+            notificationService.interestRejected(initiatorEmail, projectName, partnerName);
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // VNC-04 — confirm (2nd handshake, bilateral)
+    // ----------------------------------------------------------------------------------------
+
+    @Transactional
+    public void confirmRelationship(String auth0Id, Integer companyId, Long projectId) {
+        ResolvedActor actor = resolveActor(auth0Id);
+        CompanyProject relationship = loadParticipantRelationship(actor, companyId, projectId);
+
+        if (relationship.getStatus() != RelationshipStatus.negotiation) {
+            throw new BadRequestException("Só é possível efetivar vínculos em negociação.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (actor.isCompany()) {
+            if (relationship.getCompanyConfirmedAt() == null) {
+                relationship.setCompanyConfirmedAt(now);
+            }
+        } else {
+            if (relationship.getNpoConfirmedAt() == null) {
+                relationship.setNpoConfirmedAt(now);
+            }
+        }
+
+        Company company = relationship.getCompany();
+        Npo npo = relationship.getProject().getNpo();
+        String projectName = relationship.getProject().getTitle();
+
+        boolean bothConfirmed =
+                relationship.getCompanyConfirmedAt() != null
+                        && relationship.getNpoConfirmedAt() != null;
+        if (bothConfirmed) {
+            relationship.setStatus(RelationshipStatus.active);
+        }
+        companyProjectRepository.save(relationship);
+
+        if (bothConfirmed) {
+            notificationService.partnershipActivated(
+                    companyEmail(company), projectName, npoName(npo));
+            notificationService.partnershipActivated(
+                    npoEmail(npo), projectName, companyName(company));
+        } else if (actor.isCompany()) {
+            notificationService.confirmationRequested(
+                    npoEmail(npo), projectName, companyName(company));
+        } else {
+            notificationService.confirmationRequested(
+                    companyEmail(company), projectName, npoName(npo));
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------------------------
+
+    private ResolvedActor resolveActor(String auth0Id) {
         if (auth0Id == null || auth0Id.isBlank()) {
             throw new BadRequestException("Não foi possível identificar o usuário autenticado.");
         }
-
-        validateStatus(status);
-
         User user = userRepository.findByAuth0Id(auth0Id).orElseThrow(UserNotFoundException::new);
 
         return companyRepository
                 .findByUserId(user.getId())
-                .map(company -> listCompanyRelationships(company, status))
-                .orElseGet(() -> listNpoRelationships(user.getId(), status));
+                .map(company -> new ResolvedActor(ActorRole.COMPANY, company, null))
+                .orElseGet(
+                        () -> {
+                            Npo npo =
+                                    npoRepository
+                                            .findByUserId(user.getId())
+                                            .orElseThrow(
+                                                    () ->
+                                                            new NotFoundException(
+                                                                    "Perfil de empresa ou ONG não"
+                                                                            + " encontrado"));
+                            return new ResolvedActor(ActorRole.NPO, null, npo);
+                        });
+    }
+
+    private CompanyProject loadParticipantRelationship(
+            ResolvedActor actor, Integer companyId, Long projectId) {
+        CompanyProject relationship =
+                companyProjectRepository
+                        .findByIdWithGraph(companyId, projectId)
+                        .orElseThrow(() -> new NotFoundException("Vínculo não encontrado."));
+
+        boolean participant =
+                actor.isCompany()
+                        ? actor.company().getId().equals(relationship.getCompany().getId())
+                        : actor.npo().getId().equals(relationship.getProject().getNpo().getId());
+        if (!participant) {
+            throw new ForbiddenException("Você não participa deste vínculo.");
+        }
+        return relationship;
+    }
+
+    private void requireReceptor(ResolvedActor actor, CompanyProject relationship) {
+        boolean isReceptor =
+                actor.isCompany()
+                        ? relationship.getInitiatorType() == InitiatorType.npo
+                        : relationship.getInitiatorType() == InitiatorType.company;
+        if (!isReceptor) {
+            throw new ForbiddenException("Apenas a parte receptora pode responder a este vínculo.");
+        }
     }
 
     private void validateStatus(RelationshipStatus status) {
@@ -53,66 +321,70 @@ public class RelationshipService {
         }
     }
 
-    private List<RelationshipListItemResponse> listCompanyRelationships(
-            Company company, RelationshipStatus status) {
-        List<CompanyProject> relationships =
-                status == null
-                        ? companyProjectRepository.findVisibleRelationshipsByCompanyId(
-                                company.getId())
-                        : companyProjectRepository.findRelationshipsByCompanyIdAndStatusIn(
-                                company.getId(), List.of(status));
-
-        return relationships.stream().map(this::toCompanyResponse).toList();
-    }
-
-    private List<RelationshipListItemResponse> listNpoRelationships(
-            Integer userId, RelationshipStatus status) {
-        Npo npo =
-                npoRepository
-                        .findByUserId(userId)
-                        .orElseThrow(
-                                () ->
-                                        new NotFoundException(
-                                                "Perfil de empresa ou ONG não encontrado"));
-
-        List<CompanyProject> relationships =
-                status == null
-                        ? companyProjectRepository.findVisibleRelationshipsByNpoId(npo.getId())
-                        : companyProjectRepository.findRelationshipsByNpoIdAndStatusIn(
-                                npo.getId(), List.of(status));
-
-        return relationships.stream().map(this::toNpoResponse).toList();
-    }
-
-    private RelationshipListItemResponse toCompanyResponse(CompanyProject relationship) {
+    private RelationshipListItemResponse toCompanyViewerResponse(CompanyProject relationship) {
         Project project = relationship.getProject();
         Npo partner = project.getNpo();
+        boolean contactVisible = CONTACT_VISIBLE_STATUSES.contains(relationship.getStatus());
 
         return new RelationshipListItemResponse(
                 project.getId(),
                 project.getTitle(),
                 partner.getId(),
-                partner.getName(),
-                relationship.getStatus());
+                npoName(partner),
+                relationship.getStatus(),
+                contactVisible ? npoEmail(partner) : null,
+                contactVisible ? partner.getPhone() : null,
+                relationship.getStatus() == RelationshipStatus.pending
+                        && relationship.getInitiatorType() == InitiatorType.npo,
+                relationship.getStatus() == RelationshipStatus.negotiation
+                        && relationship.getCompanyConfirmedAt() == null);
     }
 
-    private RelationshipListItemResponse toNpoResponse(CompanyProject relationship) {
+    private RelationshipListItemResponse toNpoViewerResponse(CompanyProject relationship) {
         Project project = relationship.getProject();
         Company partner = relationship.getCompany();
+        boolean contactVisible = CONTACT_VISIBLE_STATUSES.contains(relationship.getStatus());
 
         return new RelationshipListItemResponse(
                 project.getId(),
                 project.getTitle(),
                 partner.getId(),
-                firstPresent(partner.getSocialName(), partner.getLegalName()),
-                relationship.getStatus());
+                companyName(partner),
+                relationship.getStatus(),
+                contactVisible ? companyEmail(partner) : null,
+                contactVisible ? partner.getPhone() : null,
+                relationship.getStatus() == RelationshipStatus.pending
+                        && relationship.getInitiatorType() == InitiatorType.company,
+                relationship.getStatus() == RelationshipStatus.negotiation
+                        && relationship.getNpoConfirmedAt() == null);
     }
 
-    private String firstPresent(String first, String second) {
-        if (first != null && !first.isBlank()) {
-            return first;
+    private String companyName(Company company) {
+        String social = company.getSocialName();
+        if (social != null && !social.isBlank()) {
+            return social;
         }
+        return company.getLegalName();
+    }
 
-        return second;
+    private String npoName(Npo npo) {
+        return npo.getName();
+    }
+
+    private String companyEmail(Company company) {
+        User user = company.getUser();
+        return user == null ? null : user.getEmail();
+    }
+
+    private String npoEmail(Npo npo) {
+        // Preferimos a associação já carregada via JOIN FETCH (evita N+1 na listagem); caímos no
+        // repositório apenas quando o npoUser não veio no fetch graph.
+        if (npo.getNpoUser() != null) {
+            return npo.getNpoUser().getEmail();
+        }
+        if (npo.getUserId() == null) {
+            return null;
+        }
+        return userRepository.findById(npo.getUserId()).map(User::getEmail).orElse(null);
     }
 }

--- a/backend/src/main/java/com/vinculohub/backend/service/RelationshipService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/RelationshipService.java
@@ -49,8 +49,7 @@ public class RelationshipService {
     private void validateStatus(RelationshipStatus status) {
         if (status != null
                 && !CompanyProjectRepository.VISIBLE_RELATIONSHIP_STATUSES.contains(status)) {
-            throw new BadRequestException(
-                    "Status inválido para Meus Vínculos.");
+            throw new BadRequestException("Status inválido para Meus Vínculos.");
         }
     }
 

--- a/backend/src/main/java/com/vinculohub/backend/service/notification/LoggingNotificationService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/notification/LoggingNotificationService.java
@@ -1,0 +1,61 @@
+/* (C)2026 */
+package com.vinculohub.backend.service.notification;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Stub {@link NotificationService} that logs instead of sending real e-mail. Replace with an
+ * SMTP/SendGrid-backed implementation when email infrastructure is introduced.
+ */
+@Slf4j
+@Service
+public class LoggingNotificationService implements NotificationService {
+
+    @Override
+    public void interestReceived(String recipientEmail, String projectName, String partnerName) {
+        log.info(
+                "[NOTIFICATION] interestReceived -> to={} project='{}' partner='{}'",
+                recipientEmail,
+                projectName,
+                partnerName);
+    }
+
+    @Override
+    public void interestAccepted(String recipientEmail, String projectName, String partnerName) {
+        log.info(
+                "[NOTIFICATION] interestAccepted -> to={} project='{}' partner='{}'",
+                recipientEmail,
+                projectName,
+                partnerName);
+    }
+
+    @Override
+    public void interestRejected(String recipientEmail, String projectName, String partnerName) {
+        log.info(
+                "[NOTIFICATION] interestRejected -> to={} project='{}' partner='{}'",
+                recipientEmail,
+                projectName,
+                partnerName);
+    }
+
+    @Override
+    public void confirmationRequested(
+            String recipientEmail, String projectName, String partnerName) {
+        log.info(
+                "[NOTIFICATION] confirmationRequested -> to={} project='{}' partner='{}'",
+                recipientEmail,
+                projectName,
+                partnerName);
+    }
+
+    @Override
+    public void partnershipActivated(
+            String recipientEmail, String projectName, String partnerName) {
+        log.info(
+                "[NOTIFICATION] partnershipActivated -> to={} project='{}' partner='{}'",
+                recipientEmail,
+                projectName,
+                partnerName);
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/service/notification/NotificationService.java
+++ b/backend/src/main/java/com/vinculohub/backend/service/notification/NotificationService.java
@@ -1,0 +1,28 @@
+/* (C)2026 */
+package com.vinculohub.backend.service.notification;
+
+/**
+ * Sends e-mail notifications for the relationship (vínculo) lifecycle.
+ *
+ * <p>Email infrastructure does not exist yet in this project, so the only implementation today is
+ * {@link LoggingNotificationService}, which simply logs. The semantic methods keep callers
+ * decoupled from the eventual transport (SMTP/SendGrid) and make the side effects easy to assert in
+ * unit tests.
+ */
+public interface NotificationService {
+
+    /** 1st handshake — interest sent: notifies the receptor that a partnership was proposed. */
+    void interestReceived(String recipientEmail, String projectName, String partnerName);
+
+    /** 1st handshake — accepted: notifies the initiator that contact was released. */
+    void interestAccepted(String recipientEmail, String projectName, String partnerName);
+
+    /** 1st handshake — rejected: notifies the initiator that the interest was declined. */
+    void interestRejected(String recipientEmail, String projectName, String partnerName);
+
+    /** 2nd handshake — one side confirmed: asks the other side to also confirm. */
+    void confirmationRequested(String recipientEmail, String projectName, String partnerName);
+
+    /** 2nd handshake — both confirmed: notifies a party that the partnership is now active. */
+    void partnershipActivated(String recipientEmail, String projectName, String partnerName);
+}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,0 +1,22 @@
+# =====================================================================================
+# Profile DEV — auth LOCAL (sem Auth0). NUNCA usar em produção.
+# Ativa um JwtDecoder/JwtEncoder HS256 com segredo local (DevJwtConfig), um endpoint
+# /dev/token para emitir tokens e um seed de dados (DevDataSeeder). Em produção o app
+# roda no profile default, que continua exigindo JWT do Auth0.
+# =====================================================================================
+
+# ---- DataSource (defaults p/ docker-compose.dev; sobrescrevíveis por env) ----
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/vinculohub_db}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:vinculohub}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:vinculohub}
+
+# ---- Segredo HS256 do profile dev (>=256 bits). Apenas para desenvolvimento. ----
+app.dev.jwt.secret=${DEV_JWT_SECRET:dev-secret-vinculohub-local-0123456789-abcdef}
+
+# ---- Placeholders herdados de application.properties resolvidos com valores dummy.
+# O DevJwtConfig fornece o JwtDecoder, então a auto-config do Auth0 não roda. ----
+spring.security.oauth2.resourceserver.jwt.issuer-uri=http://dev-local/
+spring.security.oauth2.resourceserver.jwt.audiences=dev-local
+AWS_S3_BUCKET=dev-bucket
+
+logging.level.com.vinculohub.backend=INFO

--- a/backend/src/main/resources/db/migration/V1.12__add_relationship_handshake_fields.sql
+++ b/backend/src/main/resources/db/migration/V1.12__add_relationship_handshake_fields.sql
@@ -1,0 +1,18 @@
+-- VNC-02/03/04: extend company_project to support the two-handshake lifecycle.
+-- initiator_type identifies which side started the 1st handshake (so the receptor
+-- can be determined for accept/reject). The *_confirmed_at columns record each
+-- side's confirmation in the 2nd handshake; status only becomes 'active' when both
+-- are set. responded_at marks when the 1st handshake was answered; expires_at
+-- supports the future 7-day expiry mediation (ADM-06).
+
+CREATE TYPE "initiator_type" AS ENUM (
+  'company',
+  'npo'
+);
+
+ALTER TABLE "company_project"
+  ADD COLUMN "initiator_type" initiator_type NOT NULL DEFAULT 'company',
+  ADD COLUMN "company_confirmed_at" timestamp,
+  ADD COLUMN "npo_confirmed_at" timestamp,
+  ADD COLUMN "responded_at" timestamp,
+  ADD COLUMN "expires_at" timestamp;

--- a/backend/src/test/java/com/vinculohub/backend/controller/RelationshipControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/RelationshipControllerTest.java
@@ -1,0 +1,269 @@
+/* (C)2026 */
+package com.vinculohub.backend.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.vinculohub.backend.database.AbstractIntegrationTest;
+import com.vinculohub.backend.model.Company;
+import com.vinculohub.backend.model.CompanyProject;
+import com.vinculohub.backend.model.CompanyProjectId;
+import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.model.User;
+import com.vinculohub.backend.model.enums.InitiatorType;
+import com.vinculohub.backend.model.enums.NpoSize;
+import com.vinculohub.backend.model.enums.RelationshipStatus;
+import com.vinculohub.backend.model.enums.UserType;
+import com.vinculohub.backend.repository.CompanyProjectRepository;
+import com.vinculohub.backend.repository.CompanyRepository;
+import com.vinculohub.backend.repository.NpoRepository;
+import com.vinculohub.backend.repository.ProjectRepository;
+import com.vinculohub.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@Transactional
+class RelationshipControllerTest extends AbstractIntegrationTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserRepository userRepository;
+    @Autowired private CompanyRepository companyRepository;
+    @Autowired private NpoRepository npoRepository;
+    @Autowired private ProjectRepository projectRepository;
+    @Autowired private CompanyProjectRepository companyProjectRepository;
+
+    private static final String COMPANY_SUB = "auth0|company";
+    private static final String NPO_SUB = "auth0|npo";
+
+    private Company company;
+    private Npo npo;
+    private Project project;
+
+    @BeforeEach
+    void setup() {
+        // The test runs in a transaction that rolls back, so no manual cleanup is needed and we
+        // avoid FK clashes with soft-deleted rows left by other tests on the shared container.
+        User companyUser =
+                userRepository.save(
+                        User.builder()
+                                .name("Empresa")
+                                .email("empresa@corp.com")
+                                .auth0Id(COMPANY_SUB)
+                                .userType(UserType.company)
+                                .build());
+        User npoUser =
+                userRepository.save(
+                        User.builder()
+                                .name("ONG")
+                                .email("contato@ong.org")
+                                .auth0Id(NPO_SUB)
+                                .userType(UserType.npo)
+                                .build());
+
+        company = new Company();
+        company.setSocialName("Corp S.A.");
+        company.setLegalName("Corporation Ltda");
+        company.setPhone("(11) 1111-1111");
+        company.setUser(companyUser);
+        company = companyRepository.save(company);
+
+        npo =
+                npoRepository.save(
+                        Npo.builder()
+                                .name("ONG Boa")
+                                .npoSize(NpoSize.small)
+                                .phone("(11) 2222-2222")
+                                .userId(npoUser.getId())
+                                .build());
+
+        project =
+                projectRepository.save(
+                        Project.builder()
+                                .npo(npo)
+                                .title("Projeto Verde")
+                                .description("Projeto de reflorestamento")
+                                .build());
+    }
+
+    private CompanyProject seedRelationship(RelationshipStatus status, InitiatorType initiator) {
+        return companyProjectRepository.save(
+                CompanyProject.builder()
+                        .id(new CompanyProjectId(company.getId(), project.getId()))
+                        .company(company)
+                        .project(project)
+                        .status(status)
+                        .initiatorType(initiator)
+                        .build());
+    }
+
+    private static org.springframework.test.web.servlet.request.RequestPostProcessor as(
+            String subject) {
+        return jwt().jwt(j -> j.subject(subject))
+                .authorities(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Test
+    @DisplayName("VNC-01: requer autenticação (401 sem token)")
+    void listRequiresAuth() throws Exception {
+        mockMvc.perform(get("/api/relationships")).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("VNC-02→04: ciclo completo empresa/ONG até status active")
+    void fullLifecycle() throws Exception {
+        // VNC-02: empresa demonstra interesse no projeto.
+        mockMvc.perform(
+                        post("/api/relationships")
+                                .with(as(COMPANY_SUB))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"projectId\":" + project.getId() + "}"))
+                .andExpect(status().isCreated());
+
+        assertEquals(
+                RelationshipStatus.pending,
+                companyProjectRepository
+                        .findByIdWithGraph(company.getId(), project.getId())
+                        .orElseThrow()
+                        .getStatus());
+
+        // ONG vê o vínculo pendente, sem contato revelado, podendo responder.
+        mockMvc.perform(get("/api/relationships?status=pending").with(as(NPO_SUB)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].projectId").value(project.getId()))
+                .andExpect(jsonPath("$[0].status").value("pending"))
+                .andExpect(jsonPath("$[0].canRespond").value(true))
+                .andExpect(jsonPath("$[0].partnerContactEmail").doesNotExist());
+
+        // VNC-03: ONG (receptora) aceita -> negotiation + contato revelado.
+        mockMvc.perform(
+                        post("/api/relationships/"
+                                        + company.getId()
+                                        + "/"
+                                        + project.getId()
+                                        + "/accept")
+                                .with(as(NPO_SUB)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/relationships").with(as(COMPANY_SUB)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].status").value("negotiation"))
+                .andExpect(jsonPath("$[0].partnerContactEmail").value("contato@ong.org"))
+                .andExpect(jsonPath("$[0].partnerContactPhone").value("(11) 2222-2222"))
+                .andExpect(jsonPath("$[0].canConfirm").value(true));
+
+        // VNC-04: ambas as partes efetivam -> active.
+        String confirmUrl =
+                "/api/relationships/" + company.getId() + "/" + project.getId() + "/confirm";
+        mockMvc.perform(post(confirmUrl).with(as(COMPANY_SUB))).andExpect(status().isOk());
+        // ainda em negociação após apenas uma confirmação
+        assertEquals(
+                RelationshipStatus.negotiation,
+                companyProjectRepository
+                        .findByIdWithGraph(company.getId(), project.getId())
+                        .orElseThrow()
+                        .getStatus());
+
+        mockMvc.perform(post(confirmUrl).with(as(NPO_SUB))).andExpect(status().isOk());
+        assertEquals(
+                RelationshipStatus.active,
+                companyProjectRepository
+                        .findByIdWithGraph(company.getId(), project.getId())
+                        .orElseThrow()
+                        .getStatus());
+    }
+
+    @Test
+    @DisplayName("VNC-03: recusar encerra o vínculo (some da listagem visível)")
+    void rejectClosesRelationship() throws Exception {
+        seedRelationship(RelationshipStatus.pending, InitiatorType.company);
+
+        mockMvc.perform(
+                        post("/api/relationships/"
+                                        + company.getId()
+                                        + "/"
+                                        + project.getId()
+                                        + "/reject")
+                                .with(as(NPO_SUB)))
+                .andExpect(status().isOk());
+
+        assertEquals(
+                RelationshipStatus.inactive,
+                companyProjectRepository
+                        .findByIdWithGraph(company.getId(), project.getId())
+                        .orElseThrow()
+                        .getStatus());
+
+        mockMvc.perform(get("/api/relationships").with(as(NPO_SUB)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("VNC-03: iniciador não pode aceitar o próprio interesse (403)")
+    void initiatorCannotAccept() throws Exception {
+        seedRelationship(RelationshipStatus.pending, InitiatorType.company);
+
+        mockMvc.perform(
+                        post("/api/relationships/"
+                                        + company.getId()
+                                        + "/"
+                                        + project.getId()
+                                        + "/accept")
+                                .with(as(COMPANY_SUB)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("VNC-02/03: ONG inicia (Propor Parceria) e a empresa receptora aceita")
+    void npoInitiatesAndCompanyAccepts() throws Exception {
+        // VNC-02: ONG propõe parceria informando projeto próprio + empresa alvo.
+        mockMvc.perform(
+                        post("/api/relationships")
+                                .with(as(NPO_SUB))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(
+                                        "{\"projectId\":"
+                                                + project.getId()
+                                                + ",\"companyId\":"
+                                                + company.getId()
+                                                + "}"))
+                .andExpect(status().isCreated());
+
+        // A empresa é a receptora (initiator = npo): vê o pendente e pode responder.
+        mockMvc.perform(get("/api/relationships?status=pending").with(as(COMPANY_SUB)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].status").value("pending"))
+                .andExpect(jsonPath("$[0].canRespond").value(true))
+                .andExpect(jsonPath("$[0].partnerInstitutionName").value("ONG Boa"));
+
+        // VNC-03: empresa aceita -> negotiation.
+        mockMvc.perform(
+                        post("/api/relationships/"
+                                        + company.getId()
+                                        + "/"
+                                        + project.getId()
+                                        + "/accept")
+                                .with(as(COMPANY_SUB)))
+                .andExpect(status().isOk());
+
+        assertEquals(
+                RelationshipStatus.negotiation,
+                companyProjectRepository
+                        .findByIdWithGraph(company.getId(), project.getId())
+                        .orElseThrow()
+                        .getStatus());
+    }
+}

--- a/backend/src/test/java/com/vinculohub/backend/database/FlywayMigrationTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/database/FlywayMigrationTest.java
@@ -66,6 +66,7 @@ class FlywayMigrationTest extends AbstractIntegrationTest {
                         "user_type",
                         "project_status",
                         "relationship_status",
-                        "project_type");
+                        "project_type",
+                        "initiator_type");
     }
 }

--- a/backend/src/test/java/com/vinculohub/backend/service/RelationshipServiceTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/service/RelationshipServiceTest.java
@@ -1,0 +1,304 @@
+/* (C)2026 */
+package com.vinculohub.backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.vinculohub.backend.dto.CreateRelationshipRequest;
+import com.vinculohub.backend.dto.RelationshipListItemResponse;
+import com.vinculohub.backend.exception.BadRequestException;
+import com.vinculohub.backend.exception.ForbiddenException;
+import com.vinculohub.backend.model.Company;
+import com.vinculohub.backend.model.CompanyProject;
+import com.vinculohub.backend.model.CompanyProjectId;
+import com.vinculohub.backend.model.Npo;
+import com.vinculohub.backend.model.Project;
+import com.vinculohub.backend.model.User;
+import com.vinculohub.backend.model.enums.InitiatorType;
+import com.vinculohub.backend.model.enums.RelationshipStatus;
+import com.vinculohub.backend.repository.CompanyProjectRepository;
+import com.vinculohub.backend.repository.CompanyRepository;
+import com.vinculohub.backend.repository.NpoRepository;
+import com.vinculohub.backend.repository.ProjectRepository;
+import com.vinculohub.backend.repository.UserRepository;
+import com.vinculohub.backend.service.notification.NotificationService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RelationshipServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private CompanyRepository companyRepository;
+    @Mock private NpoRepository npoRepository;
+    @Mock private ProjectRepository projectRepository;
+    @Mock private CompanyProjectRepository companyProjectRepository;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks private RelationshipService relationshipService;
+
+    private static final String COMPANY_AUTH = "auth0|company";
+    private static final String NPO_AUTH = "auth0|npo";
+
+    private User companyUser;
+    private User npoUser;
+    private Company company;
+    private Npo npo;
+    private Project project;
+
+    @BeforeEach
+    void setup() {
+        companyUser = User.builder().id(1).email("empresa@corp.com").auth0Id(COMPANY_AUTH).build();
+        npoUser = User.builder().id(2).email("contato@ong.org").auth0Id(NPO_AUTH).build();
+
+        company = new Company();
+        company.setId(10);
+        company.setSocialName("Corp S.A.");
+        company.setLegalName("Corporation Ltda");
+        company.setPhone("(11) 1111-1111");
+        company.setUser(companyUser);
+
+        npo =
+                Npo.builder()
+                        .id(20)
+                        .name("ONG Boa")
+                        .userId(npoUser.getId())
+                        .phone("(11) 2222-2222")
+                        .build();
+        project = Project.builder().id(100L).npo(npo).title("Projeto Verde").build();
+    }
+
+    private void mockCompanyActor() {
+        when(userRepository.findByAuth0Id(COMPANY_AUTH)).thenReturn(Optional.of(companyUser));
+        when(companyRepository.findByUserId(companyUser.getId())).thenReturn(Optional.of(company));
+    }
+
+    private void mockNpoActor() {
+        when(userRepository.findByAuth0Id(NPO_AUTH)).thenReturn(Optional.of(npoUser));
+        when(companyRepository.findByUserId(npoUser.getId())).thenReturn(Optional.empty());
+        when(npoRepository.findByUserId(npoUser.getId())).thenReturn(Optional.of(npo));
+    }
+
+    private CompanyProject relationship(RelationshipStatus status, InitiatorType initiator) {
+        return CompanyProject.builder()
+                .id(new CompanyProjectId(company.getId(), project.getId()))
+                .company(company)
+                .project(project)
+                .status(status)
+                .initiatorType(initiator)
+                .build();
+    }
+
+    // ---------------------------------------------------------------------------------------- list
+
+    @Test
+    @DisplayName("VNC-01: status inválido para o painel lança BadRequest")
+    void listRejectsInvalidStatus() {
+        assertThrows(
+                BadRequestException.class,
+                () ->
+                        relationshipService.listMyRelationships(
+                                COMPANY_AUTH, RelationshipStatus.inactive));
+    }
+
+    @Test
+    @DisplayName("VNC-01: contato fica oculto enquanto pending e visível em negotiation")
+    void listHidesContactWhilePending() {
+        mockCompanyActor();
+        when(userRepository.findById(npo.getUserId())).thenReturn(Optional.of(npoUser));
+        when(companyProjectRepository.findVisibleRelationshipsByCompanyId(company.getId()))
+                .thenReturn(
+                        List.of(
+                                relationship(RelationshipStatus.pending, InitiatorType.npo),
+                                relationship(
+                                        RelationshipStatus.negotiation, InitiatorType.company)));
+
+        List<RelationshipListItemResponse> result =
+                relationshipService.listMyRelationships(COMPANY_AUTH, null);
+
+        assertEquals(2, result.size());
+        RelationshipListItemResponse pending = result.get(0);
+        assertEquals("ONG Boa", pending.partnerInstitutionName());
+        assertNull(pending.partnerContactEmail());
+        assertTrue(pending.canRespond(), "company é receptor quando npo iniciou");
+
+        RelationshipListItemResponse negotiation = result.get(1);
+        assertEquals("contato@ong.org", negotiation.partnerContactEmail());
+        assertEquals("(11) 2222-2222", negotiation.partnerContactPhone());
+        assertTrue(negotiation.canConfirm());
+    }
+
+    // -------------------------------------------------------------------------------------- create
+
+    @Test
+    @DisplayName("VNC-02: empresa cria vínculo pending e notifica a ONG receptora")
+    void createByCompanyNotifiesNpo() {
+        mockCompanyActor();
+        when(projectRepository.findById(project.getId())).thenReturn(Optional.of(project));
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(Optional.empty());
+        when(userRepository.findById(npo.getUserId())).thenReturn(Optional.of(npoUser));
+
+        relationshipService.createRelationship(
+                COMPANY_AUTH, new CreateRelationshipRequest(project.getId(), null));
+
+        ArgumentCaptor<CompanyProject> captor = ArgumentCaptor.forClass(CompanyProject.class);
+        verify(companyProjectRepository).save(captor.capture());
+        assertEquals(RelationshipStatus.pending, captor.getValue().getStatus());
+        assertEquals(InitiatorType.company, captor.getValue().getInitiatorType());
+        verify(notificationService).interestReceived(eq("contato@ong.org"), any(), any());
+    }
+
+    @Test
+    @DisplayName("VNC-02: ONG não pode propor parceria com projeto que não é seu")
+    void createByNpoRejectsForeignProject() {
+        mockNpoActor();
+        Npo otherNpo = Npo.builder().id(99).name("Outra").build();
+        Project foreign = Project.builder().id(100L).npo(otherNpo).title("Alheio").build();
+        when(projectRepository.findById(foreign.getId())).thenReturn(Optional.of(foreign));
+
+        assertThrows(
+                BadRequestException.class,
+                () ->
+                        relationshipService.createRelationship(
+                                NPO_AUTH,
+                                new CreateRelationshipRequest(foreign.getId(), company.getId())));
+        verify(companyProjectRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("VNC-02: vínculo visível já existente é rejeitado")
+    void createRejectsDuplicateVisible() {
+        mockCompanyActor();
+        when(projectRepository.findById(project.getId())).thenReturn(Optional.of(project));
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(
+                        Optional.of(
+                                relationship(
+                                        RelationshipStatus.negotiation, InitiatorType.company)));
+
+        assertThrows(
+                BadRequestException.class,
+                () ->
+                        relationshipService.createRelationship(
+                                COMPANY_AUTH,
+                                new CreateRelationshipRequest(project.getId(), null)));
+        verify(companyProjectRepository, never()).save(any());
+    }
+
+    // ------------------------------------------------------------------------------- accept/reject
+
+    @Test
+    @DisplayName("VNC-03: receptor (ONG) aceita -> negotiation e notifica iniciador")
+    void acceptByReceptorMovesToNegotiation() {
+        mockNpoActor();
+        CompanyProject rel = relationship(RelationshipStatus.pending, InitiatorType.company);
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(Optional.of(rel));
+
+        relationshipService.acceptRelationship(NPO_AUTH, company.getId(), project.getId());
+
+        assertEquals(RelationshipStatus.negotiation, rel.getStatus());
+        assertTrue(rel.getRespondedAt() != null);
+        verify(notificationService).interestAccepted(eq("empresa@corp.com"), any(), any());
+    }
+
+    @Test
+    @DisplayName("VNC-03: iniciador não pode aceitar o próprio interesse (Forbidden)")
+    void acceptByInitiatorIsForbidden() {
+        // Company initiated; company tries to accept -> it is NOT the receptor.
+        mockCompanyActor();
+        CompanyProject rel = relationship(RelationshipStatus.pending, InitiatorType.company);
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(Optional.of(rel));
+
+        assertThrows(
+                ForbiddenException.class,
+                () ->
+                        relationshipService.acceptRelationship(
+                                COMPANY_AUTH, company.getId(), project.getId()));
+    }
+
+    @Test
+    @DisplayName("VNC-03: recusar encerra o vínculo (inactive)")
+    void rejectClosesRelationship() {
+        mockNpoActor();
+        CompanyProject rel = relationship(RelationshipStatus.pending, InitiatorType.company);
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(Optional.of(rel));
+
+        relationshipService.rejectRelationship(NPO_AUTH, company.getId(), project.getId());
+
+        assertEquals(RelationshipStatus.inactive, rel.getStatus());
+        verify(notificationService).interestRejected(eq("empresa@corp.com"), any(), any());
+    }
+
+    // ------------------------------------------------------------------------------------- confirm
+
+    @Test
+    @DisplayName("VNC-04: uma confirmação mantém negotiation e pede confirmação à outra parte")
+    void confirmSingleSideStaysNegotiation() {
+        mockCompanyActor();
+        CompanyProject rel = relationship(RelationshipStatus.negotiation, InitiatorType.company);
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(Optional.of(rel));
+        when(userRepository.findById(npo.getUserId())).thenReturn(Optional.of(npoUser));
+
+        relationshipService.confirmRelationship(COMPANY_AUTH, company.getId(), project.getId());
+
+        assertEquals(RelationshipStatus.negotiation, rel.getStatus());
+        assertTrue(rel.getCompanyConfirmedAt() != null);
+        assertNull(rel.getNpoConfirmedAt());
+        verify(notificationService).confirmationRequested(eq("contato@ong.org"), any(), any());
+    }
+
+    @Test
+    @DisplayName("VNC-04: confirmação das duas partes ativa o vínculo e notifica ambos")
+    void confirmBothSidesActivates() {
+        mockNpoActor();
+        CompanyProject rel = relationship(RelationshipStatus.negotiation, InitiatorType.company);
+        rel.setCompanyConfirmedAt(LocalDateTime.now()); // empresa já confirmou
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(Optional.of(rel));
+        when(userRepository.findById(npo.getUserId())).thenReturn(Optional.of(npoUser));
+
+        relationshipService.confirmRelationship(NPO_AUTH, company.getId(), project.getId());
+
+        assertEquals(RelationshipStatus.active, rel.getStatus());
+        verify(notificationService).partnershipActivated(eq("empresa@corp.com"), any(), any());
+        verify(notificationService).partnershipActivated(eq("contato@ong.org"), any(), any());
+    }
+
+    @Test
+    @DisplayName("VNC-04: só é possível efetivar a partir de negotiation")
+    void confirmRequiresNegotiation() {
+        mockCompanyActor();
+        CompanyProject rel = relationship(RelationshipStatus.pending, InitiatorType.company);
+        when(companyProjectRepository.findByIdWithGraph(company.getId(), project.getId()))
+                .thenReturn(Optional.of(rel));
+
+        assertThrows(
+                BadRequestException.class,
+                () ->
+                        relationshipService.confirmRelationship(
+                                COMPANY_AUTH, company.getId(), project.getId()));
+        assertFalse(rel.getStatus() == RelationshipStatus.active);
+    }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,46 @@
+# =====================================================================================
+# Stack de DESENVOLVIMENTO — auth LOCAL (sem Auth0).
+# Sobe Postgres + backend no profile `dev`: JWT assinado localmente (HS256), endpoint
+# /dev/token para emitir tokens e seed automático de dados. NÃO usar em produção
+# (o docker-compose.yml principal continua sendo o de produção, com Auth0).
+#
+# Uso:
+#   docker compose -f docker-compose.dev.yml up --build
+#   curl "http://localhost:8088/dev/token?sub=dev|company&roles=COMPANY"
+# =====================================================================================
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_USER=vinculohub
+      - POSTGRES_PASSWORD=vinculohub
+      - POSTGRES_DB=vinculohub_db
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U vinculohub -d vinculohub_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - dev_db_data:/var/lib/postgresql/data
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+      - BACKEND_PORT=8080
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:5432/vinculohub_db
+      - SPRING_DATASOURCE_USERNAME=vinculohub
+      - SPRING_DATASOURCE_PASSWORD=vinculohub
+      - FRONTEND_URL=http://localhost:5173,http://localhost
+    ports:
+      - "${DEV_BACKEND_PORT:-8088}:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  dev_db_data:


### PR DESCRIPTION
## Issue Link
Closes #262

## Description
Backend completo do épico **Vínculos** — a tela central "Meus Vínculos" e todo o ciclo de parceria entre Empresas e ONGs, sempre atrelado a um **Projeto**. Continua o trabalho de leitura já iniciado na branch e adiciona a escrita (1º e 2º apertos de mão), notificações, documentação e tooling de teste.

**Fluxo implementado**
- **VNC-01 — Painel:** `GET /api/relationships` (filtro opcional por status). Cada item traz projeto, instituição parceira e status, mais as flags `canRespond`/`canConfirm`. Sem chat/mensagens.
- **VNC-02 — Iniciar (1º aperto, envio):** `POST /api/relationships`. Empresa informa só o projeto; ONG informa um projeto **próprio** + a empresa alvo. Valida projeto **ativo**, duplicidade e status `pending`.
- **VNC-03 — Responder (1º aperto, resposta):** `POST /{companyId}/{projectId}/accept|reject`, restrito ao **receptor**. Aceitar → `negotiation` e **revela contato** (e-mail/telefone) das duas partes; recusar → `inactive`.
- **VNC-04 — Efetivar (2º aperto):** `POST /{companyId}/{projectId}/confirm`. Vira **`active`** só após a confirmação **bilateral** — e só vínculos ativos alimentarão o Dashboard de Impacto ESG.

**Como foi construído**
- Migration `V1.12`: enum `initiator_type` + colunas `company_confirmed_at`, `npo_confirmed_at`, `responded_at`, `expires_at` em `company_project`.
- `RelationshipService` resolve o ator (Empresa/ONG) pelo usuário autenticado, já que empresa não tem role dedicada.
- `NotificationService` desacoplado (stub que loga; e-mail real fica para depois — não há infra de e-mail hoje).
- **Swagger/OpenAPI** documentado e liberado; **coleção Bruno** versionada em `backend/docs/api/vinculos/`.
- **Profile `dev`** com auth local (JWT HS256), emissor `/dev/token` e seed automático, mais `docker-compose.dev.yml` — permite testar autenticado sem Auth0. Produção não muda (segue no Auth0).

## Task Notes
- **Code review** próprio aplicado: validação de projeto ativo (VNC-02), eliminação de N+1 na revelação de contato (`JOIN FETCH` dos usuários), charset UTF-8 no segredo dev e teste E2E do caminho "ONG inicia".
- **Testes:** `./mvnw test` → **175 passando, 0 falhas** (unit + integração com Testcontainers; a migration V1.12 é aplicada no banco real do teste).
- **Smoke autenticado** validado de ponta a ponta via curl no stack dev (Docker): `pending → negotiation (contato revelado) → active`, com as 5 notificações disparando na ordem.
- **Fora de escopo (follow-up):** entrega real de e-mail (hoje é stub) e o job de expiração de 7 dias do ADM-06 (a coluna `expires_at` já fica pronta).
- O profile `dev`/`/dev/token` é **exclusivo de desenvolvimento**; em produção o app valida JWT do Auth0 normalmente.

## Screenshots
N/A — mudança somente de backend. O fluxo autenticado pode ser reproduzido pela coleção Bruno (`backend/docs/api/vinculos`) ou pelo Swagger (`/swagger-ui.html`); instruções no README.
