### PR TITLE
fix(auth): redirect to /cadastro when Auth0 user has no DB record

### DIFF
--- a/frontend/src/components/auth/AuthRoleRedirect.tsx
+++ b/frontend/src/components/auth/AuthRoleRedirect.tsx
@@ -27,6 +27,7 @@ type Auth0User = {
 };
 
 type AuthenticatedProfile = {
+  userId?: number | null;
   userType?: "admin" | "npo" | "company" | null;
   npoId?: number | null;
   companyId?: number | null;
@@ -109,6 +110,15 @@ export function AuthRoleRedirect() {
         const profile = await getAuthenticatedProfile(token);
         logger.info("AuthRedirect", "Profile loaded", profile);
 
+        const isSignupFlow =
+          hasNpoDraft || hasCompanyDraft || npoDraftSubmitted || companyDraftSubmitted;
+        if (!isSignupFlow && profile !== null && profile.userId === null) {
+          logger.info("AuthRedirect", "Auth0 user has no DB record — redirecting to /cadastro");
+          showToast("Para continuar, complete seu cadastro na plataforma.");
+          navigate("/cadastro", { replace: true });
+          return;
+        }
+
         const tokenRoles = getRolesFromToken(token);
         const userRoles = getRolesFromUser(user);
         const role = profileRole(profile) ?? resolvePrimaryRole([...tokenRoles, ...userRoles]);
@@ -161,6 +171,9 @@ export function AuthRoleRedirect() {
       try {
         const token = await getAccessTokenSilently();
         const profile = await getAuthenticatedProfile(token);
+        if (!profile || profile.userId === null) {
+          return;
+        }
         const tokenRoles = getRolesFromToken(token);
         const userRoles = getRolesFromUser(user);
         const role = profileRole(profile) ?? resolvePrimaryRole([...tokenRoles, ...userRoles]);

--- a/frontend/src/components/auth/AuthRoleRedirect.tsx
+++ b/frontend/src/components/auth/AuthRoleRedirect.tsx
@@ -1,8 +1,10 @@
 import { useAuth0 } from "@auth0/auth0-react";
+import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { registerCompany, type CompanyRegistrationPayload } from "../../api/company";
+import { AUTH_PROFILE_QUERY_KEY } from "../../hooks/useAuthProfile";
 import { api } from "../../services/api";
 import type { WizardFormData } from "../../types/wizard.types";
 import { logger } from "../../utils/logger";
@@ -47,6 +49,7 @@ export function AuthRoleRedirect() {
   const location = useLocation();
   const navigate = useNavigate();
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const shouldRedirect = sessionStorage.getItem(loginCompletedKey) === "true";
@@ -143,6 +146,10 @@ export function AuthRoleRedirect() {
 
         const justSubmittedDraft =
           npoDraftSubmitted || companyDraftSubmitted || hasNpoDraft || hasCompanyDraft
+
+        if (justSubmittedDraft) {
+          void queryClient.invalidateQueries({ queryKey: AUTH_PROFILE_QUERY_KEY });
+        }
 
         if (returnTo && !justSubmittedDraft) {
           logger.info("AuthRedirect", `Restoring deep-link to ${returnTo}`);

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import { useAuth0 } from '@auth0/auth0-react';
 import { useEffect, type ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
+import { useAuthProfile } from '../../hooks/useAuthProfile';
 
 const ROLES_CLAIM = "https://vinculohub/roles";
 
@@ -14,6 +15,7 @@ type ProtectedRouteProps = {
 
 export function ProtectedRoute({ children, requiredRole, requiredRoles }: ProtectedRouteProps) {
   const { isAuthenticated, isLoading, loginWithRedirect, user } = useAuth0();
+  const { data: profile, isLoading: isProfileLoading } = useAuthProfile();
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -28,8 +30,12 @@ export function ProtectedRoute({ children, requiredRole, requiredRoles }: Protec
     }
   }, [isAuthenticated, isLoading, loginWithRedirect]);
 
-  if (isLoading || !isAuthenticated) {
+  if (isLoading || !isAuthenticated || isProfileLoading) {
     return <p>Carregando...</p>;
+  }
+
+  if (profile?.userId === null) {
+    return <Navigate to="/cadastro" replace />;
   }
 
   const rawRoles = (user as Record<string, unknown> | undefined)?.[ROLES_CLAIM];

--- a/frontend/src/components/general/Header.tsx
+++ b/frontend/src/components/general/Header.tsx
@@ -8,6 +8,7 @@ import LanguageIcon from "@mui/icons-material/Language"
 import MenuIcon from "@mui/icons-material/Menu"
 import CloseIcon from "@mui/icons-material/Close"
 import { resolveDashboardPath } from "../../utils/dashboardPath"
+import { useAuthProfile } from "../../hooks/useAuthProfile"
 
 const auth0Audience = import.meta.env.VITE_AUTH0_AUDIENCE
 
@@ -16,6 +17,10 @@ export function Header() {
   const [isAuthRedirectModalOpen, setIsAuthRedirectModalOpen] = useState(false)
   const navigate = useNavigate()
   const { isAuthenticated, loginWithRedirect, logout, user } = useAuth0()
+  const { data: profile } = useAuthProfile()
+
+  // A user is a platform user only when Auth0-authenticated AND has a DB record
+  const isPlatformUser = isAuthenticated && profile?.userId != null
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen)
   const openLoginRedirectNotice = () => {
@@ -49,9 +54,9 @@ export function Header() {
     })
   }
 
-  const handleAuthClick = isAuthenticated ? handleLogout : openLoginRedirectNotice
-  const authButtonLabel = isAuthenticated ? "Sair" : "Entrar"
-  const homePath = isAuthenticated ? resolveDashboardPath(user) : "/"
+  const handleAuthClick = isPlatformUser ? handleLogout : openLoginRedirectNotice
+  const authButtonLabel = isPlatformUser ? "Sair" : "Entrar"
+  const homePath = isPlatformUser ? resolveDashboardPath(user) : "/"
 
   return (
     <header className="bg-vinculo-dark w-full shadow-md relative z-50">
@@ -68,7 +73,7 @@ export function Header() {
         </Link>
 
         <div className="hidden md:flex gap-4">
-          {!isAuthenticated && (
+          {!isPlatformUser && (
             <Link to="/cadastro/instituicao">
               <BaseButton
                 variant="outline"
@@ -97,7 +102,7 @@ export function Header() {
 
       {isMenuOpen && (
         <div className="md:hidden bg-vinculo-dark border-t border-white/10 px-6 py-8 flex flex-col gap-4 animate-in slide-in-from-top duration-300">
-          {!isAuthenticated && (
+          {!isPlatformUser && (
             <BaseButton
               variant="outline"
               fullWidth

--- a/frontend/src/hooks/useAuthProfile.ts
+++ b/frontend/src/hooks/useAuthProfile.ts
@@ -1,0 +1,19 @@
+import { useAuth0 } from "@auth0/auth0-react"
+import { useQuery } from "@tanstack/react-query"
+import { fetchAuthenticatedProfile } from "../api/me"
+
+export const AUTH_PROFILE_QUERY_KEY = ["auth-profile"] as const
+
+export function useAuthProfile() {
+  const { isAuthenticated, isLoading, getAccessTokenSilently } = useAuth0()
+  return useQuery({
+    queryKey: AUTH_PROFILE_QUERY_KEY,
+    queryFn: async () => {
+      const token = await getAccessTokenSilently()
+      return fetchAuthenticatedProfile(token)
+    },
+    enabled: isAuthenticated && !isLoading,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  })
+}


### PR DESCRIPTION
## Issue Link
Closes #275

## Description

### Problema
Quando um usuário autenticava com sucesso pelo Auth0 mas não tinha registro correspondente no banco de dados, o app:
1. Chamava `/api/me/profile` e recebia `{ userId: null, registrationCompleted: false }`
2. Resolvia o role pelo JWT claim do Auth0 (ex: `NPO`)
3. Redirecionava para `/ong/dashboard`
4. Todas as chamadas de API falhavam com 404 (UserNotFoundException) e o dashboard ficava quebrado

### Solução
A correção está em `AuthRoleRedirect.tsx`, nos dois fluxos de redirecionamento:

**Fluxo de login (`redirectByRole`):**
- Após buscar o perfil, verifica se `profile.userId === null` E se não é um fluxo de cadastro (sem draft salvo)
- Se sim: exibe toast informativo e redireciona para `/cadastro`

**Fluxo de sessão restaurada (`redirectRestoredSession`):**
- Guarda contra `userId === null` para não redirecionar sessões restauradas para dashboards que não carregarão

**Tipo local `AuthenticatedProfile`:**
- Campo `userId` estava ausente — adicionado como `userId?: number | null`

## Task Notes

- O `MeController` já retornava `{ userId: null, ... }` neste caso — apenas o frontend precisava tratar a resposta
- O fluxo de cadastro (draft em sessionStorage) não é afetado: o draft é submetido *antes* da verificação, então após o cadastro bem-sucedido o `userId` já existe no DB
- Erros de rede em `/api/me/profile` retornam `null` (não `{ userId: null }`), portanto não são afetados pela verificação `profile !== null`

## Screenshots
N/A — correção de fluxo de redirecionamento