### PR TITLE
fix(tests): corrige violações de FK na limpeza dos testes de integração

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -149,6 +149,23 @@
 			</plugin>
 
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<!--
+						Ordem de execução determinística das classes de teste.
+						Sem isso o Surefire usa runOrder=filesystem, que varia entre
+						sistemas operacionais (Linux do CI vs. macOS local). Como os
+						testes de integração compartilham um único container Postgres
+						e só limpam o estado no @BeforeEach, uma ordem diferente pode
+						expor (ou esconder) violações de FK entre classes. Fixar a
+						ordem garante que "passou no CI" signifique "passa em todo lugar".
+					-->
+					<runOrder>alphabetical</runOrder>
+				</configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>

--- a/backend/src/test/java/com/vinculohub/backend/controller/NpoReportControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/NpoReportControllerTest.java
@@ -50,8 +50,11 @@ class NpoReportControllerTest extends AbstractIntegrationTest {
         jdbcTemplate.update("DELETE FROM npo_report");
         jdbcTemplate.update("DELETE FROM company_project");
         jdbcTemplate.update("DELETE FROM project_ods");
-        documentRepository.deleteAll();
-        projectRepository.deleteAll();
+        jdbcTemplate.update("DELETE FROM document");
+        // DELETE direto: projectRepository.deleteAll() não enxerga projetos com
+        // soft delete (@SQLRestriction "deleted_at IS NULL"), deixando linhas
+        // remanescentes que violam project_npo_id_fkey ao apagar a npo.
+        jdbcTemplate.update("DELETE FROM project");
         npoRepository.deleteAll();
         companyRepository.deleteAll();
         addressRepository.deleteAll();

--- a/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/controller/ProjectControllerTest.java
@@ -20,6 +20,7 @@ import com.vinculohub.backend.model.enums.NpoSize;
 import com.vinculohub.backend.model.enums.ProjectStatus;
 import com.vinculohub.backend.model.enums.ProjectType;
 import com.vinculohub.backend.model.enums.UserType;
+import com.vinculohub.backend.repository.CompanyRepository;
 import com.vinculohub.backend.repository.NpoRepository;
 import com.vinculohub.backend.repository.OdsRepository;
 import com.vinculohub.backend.repository.ProjectRepository;
@@ -41,6 +42,7 @@ class ProjectControllerTest extends AbstractIntegrationTest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private ProjectRepository projectRepository;
+    @Autowired private CompanyRepository companyRepository;
     @Autowired private NpoRepository npoRepository;
     @Autowired private OdsRepository odsRepository;
     @Autowired private UserRepository userRepository;
@@ -55,6 +57,7 @@ class ProjectControllerTest extends AbstractIntegrationTest {
     @BeforeEach
     void setup() {
         projectRepository.deleteAll();
+        companyRepository.deleteAll();
         npoRepository.deleteAll();
         userRepository.deleteAll();
 


### PR DESCRIPTION
## Issue Link
Closes #

## Description
Os testes de integração do backend estavam falhando (23 erros em `ProjectControllerTest` e, após corrigi-los, 11 erros em `NpoReportControllerTest`) por violações de chave estrangeira durante a limpeza do banco.

As classes de teste de integração compartilham **um único container Postgres** (Testcontainers, iniciado uma vez em `AbstractIntegrationTest` e nunca reiniciado) e limpam o estado apenas no `@BeforeEach`. Assim, os dados da última execução de uma classe vazam para a próxima, e as falhas de FK aparecem dependendo da ordem de execução.

Foram corrigidas duas causas:

1. **`company_user_id_fkey` em `ProjectControllerTest`** — o `setup()` apagava `users` sem apagar `company` antes. Como `company.user_id` referencia `users.id`, o `userRepository.deleteAll()` falhava quando havia empresas remanescentes. Adicionado `companyRepository.deleteAll()` antes de `userRepository.deleteAll()`.

2. **`project_npo_id_fkey` em `NpoReportControllerTest`** — o `setup()` usava `projectRepository.deleteAll()`, que **não enxerga projetos com soft delete**: todas as entidades têm `@SQLRestriction("deleted_at IS NULL")`, então `findAll()` (usado internamente pelo `deleteAll()`) filtra as linhas marcadas como deletadas. Como o endpoint `DELETE /api/projects/{id}` faz **soft delete** (`project.setDeletedAt(...)`), a linha do projeto permanece no banco e continua referenciando a `npo`. Ao apagar a `npo` (hard delete), a FK era violada. Passou a usar `DELETE` direto via `jdbcTemplate` em `document` e `project`, alinhado ao padrão já adotado em `NpoProfileControllerTest` e `CompanyPortfolioControllerTest`.

3. **Ordem de execução determinística (`backend/pom.xml`)** — adicionado `runOrder=alphabetical` ao `maven-surefire-plugin`. Sem isso o Surefire usava o padrão `filesystem`, cuja ordem varia entre o Linux do CI e o macOS local; era por isso que a suíte ficava verde no CI mas vermelha localmente (o mesmo erro de FK chegou a aparecer no CI da branch `feat/288`). Com a ordem fixa, "passou no CI" passa a significar "passa em qualquer ambiente".

## Task Notes
- Causa raiz confirmada: `@SQLRestriction` (filtro de leitura) combinado com soft delete torna `repository.deleteAll()` incapaz de remover linhas logicamente deletadas, deixando FKs reais pendentes.
- A falha foi reproduzida na branch `development` antes da correção (mesmos 23 erros de `company_user_id_fkey`).
- Nenhuma alteração em código de produção — apenas testes e configuração do build.
- Base do PR: `development`.
- **Dívida técnica (PR futuro):** padronizar a limpeza dos testes de integração — a fragilidade de raiz é a limpeza manual só no `@BeforeEach` + container compartilhado + `deleteAll()` cego a soft delete. O ideal seria unificar numa única abordagem (DELETE direto via `jdbcTemplate` ou `@Transactional` com rollback, como o `RelationshipControllerTest` já faz).

## Screenshots
N/A (mudança apenas em testes). Resultado da suíte completa:

```
Tests run: 190, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
