### PR TITLE
[WIP] feat: simple data seeder implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ VITE_API_URL=http://localhost:8080
 VITE_AUTH0_DOMAIN=your-tenant.us.auth0.com
 VITE_AUTH0_CLIENT_ID=your-auth0-spa-client-id
 VITE_AUTH0_AUDIENCE=https://api.vinculohub
+
+# ---- Development and E2E scenarios (optional) ----
+APP_TEST_SCENARIOS_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -47,6 +47,34 @@ Para parar todos os serviços, execute: `docker compose down`.
 
 ---
 
+## Cenários de dados para desenvolvimento e E2E
+
+O compose principal pode carregar um catálogo fixo de empresas, ONGs, projetos, vínculos e
+denúncias em um banco funcionalmente vazio. A carga é opcional:
+
+```dotenv
+APP_TEST_SCENARIOS_ENABLED=true
+```
+
+Antes de subir a aplicação, devem existir na tabela `users`, com os tipos indicados, as contas:
+
+- `e2e.company.empty@vinculohub.test` (`company`)
+- `e2e.company.active@vinculohub.test` (`company`)
+- `e2e.company.multiple@vinculohub.test` (`company`)
+- `e2e.npo.projects@vinculohub.test` (`npo`)
+- `e2e.npo.reported@vinculohub.test` (`npo`)
+
+Esses usuários também devem corresponder às contas de teste mantidas no Auth0. A feature apenas
+resolve os registros locais por e-mail: não chama a Management API, não cria e não atualiza usuários
+no Auth0.
+
+O catálogo inclui empresa sem vínculo, empresa com vínculo ativo, empresa com múltiplos vínculos,
+ONG com três projetos ativos e ONG com duas denúncias. A carga inteira ocorre em uma transação e
+falha sem persistir dados quando falta um usuário, seu tipo é incompatível ou alguma tabela funcional
+já contém registros. Para recriar o ambiente, use um banco vazio e execute `docker compose up`.
+
+---
+
 ## 🛠️ Rodando Manualmente (Sem Docker)
 
 Se preferir rodar os serviços individualmente para desenvolvimento mais focado:

--- a/backend/src/main/java/com/vinculohub/backend/config/TestScenarioSeeder.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/TestScenarioSeeder.java
@@ -1,0 +1,75 @@
+/* (C)2026 */
+package com.vinculohub.backend.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "app.test-scenarios.enabled", havingValue = "true")
+public class TestScenarioSeeder implements CommandLineRunner {
+
+    private static final String DEFINITIONS = "db/test-scenarios/01_scenario_definitions.sql";
+    private static final String PERSISTENCE = "db/test-scenarios/02_scenario_persistence.sql";
+
+    private final JdbcTemplate jdbc;
+    private final PlatformTransactionManager transactionManager;
+
+    @Override
+    public void run(String... args) {
+        new TransactionTemplate(transactionManager)
+                .executeWithoutResult(
+                        ignored -> {
+                            execute(DEFINITIONS);
+                            validateEmptyDatabase();
+                            validateUsers();
+                            execute(PERSISTENCE);
+                        });
+        log.info("Development and E2E test scenarios loaded.");
+    }
+
+    private void validateEmptyDatabase() {
+        String populated =
+                jdbc.queryForObject("SELECT populated FROM scenario_database_guard", String.class);
+        if (!populated.isEmpty()) {
+            throw new IllegalStateException(
+                    "Test scenarios require an empty functional database. Populated tables: "
+                            + populated);
+        }
+    }
+
+    private void validateUsers() {
+        String invalid =
+                jdbc.queryForObject(
+                        """
+                        SELECT string_agg(s.email || ' (expected ' || s.user_type || ', found ' ||
+                            COALESCE(u.user_type::text, 'missing') || ')', ', ' ORDER BY s.email)
+                        FROM scenario_user s LEFT JOIN users u ON lower(u.email) = lower(s.email)
+                        WHERE u.id IS NULL OR u.user_type::text <> s.user_type
+                        """,
+                        String.class);
+        if (invalid != null) {
+            throw new IllegalStateException(
+                    "Required scenario users are missing or incompatible: " + invalid);
+        }
+    }
+
+    private void execute(String path) {
+        jdbc.execute(
+                (ConnectionCallback<Void>)
+                        connection -> {
+                            ScriptUtils.executeSqlScript(connection, new ClassPathResource(path));
+                            return null;
+                        });
+    }
+}

--- a/backend/src/main/java/com/vinculohub/backend/config/dev/DevDataSeeder.java
+++ b/backend/src/main/java/com/vinculohub/backend/config/dev/DevDataSeeder.java
@@ -14,6 +14,7 @@ import com.vinculohub.backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @Profile("dev")
+@ConditionalOnProperty(
+        prefix = "app.test-scenarios",
+        name = "enabled",
+        havingValue = "false",
+        matchIfMissing = true)
 @RequiredArgsConstructor
 public class DevDataSeeder implements CommandLineRunner {
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,3 +26,6 @@ app.frontend.url=${FRONTEND_URL:http://localhost:5173,http://localhost}
 app.auth0.roles-claim=${AUTH0_ROLES_CLAIM:https://vinculohub/roles}
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${AUTH0_ISSUER_URI}
 spring.security.oauth2.resourceserver.jwt.audiences=${AUTH0_AUDIENCE}
+
+# ---- Optional development and E2E scenarios ----
+app.test-scenarios.enabled=${APP_TEST_SCENARIOS_ENABLED:false}

--- a/backend/src/main/resources/db/test-scenarios/01_scenario_definitions.sql
+++ b/backend/src/main/resources/db/test-scenarios/01_scenario_definitions.sql
@@ -1,0 +1,79 @@
+CREATE TEMP TABLE scenario_user (
+    logical_key TEXT PRIMARY KEY, email TEXT UNIQUE NOT NULL, user_type TEXT NOT NULL
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_address (
+    logical_key TEXT PRIMARY KEY, state TEXT, state_code CHAR(2), city TEXT, street TEXT,
+    number TEXT, zip_code TEXT
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_company (
+    logical_key TEXT PRIMARY KEY, user_key TEXT REFERENCES scenario_user(logical_key),
+    address_key TEXT REFERENCES scenario_address(logical_key), legal_name TEXT, social_name TEXT,
+    description TEXT, cnpj TEXT, phone TEXT
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_npo (
+    logical_key TEXT PRIMARY KEY, user_key TEXT REFERENCES scenario_user(logical_key),
+    address_key TEXT REFERENCES scenario_address(logical_key), name TEXT, description TEXT,
+    npo_size TEXT, cpf TEXT, phone TEXT, environmental BOOLEAN, social BOOLEAN, governance BOOLEAN
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_project (
+    logical_key TEXT PRIMARY KEY, npo_key TEXT REFERENCES scenario_npo(logical_key), title TEXT,
+    description TEXT, status TEXT, project_type TEXT, budget NUMERIC, invested NUMERIC,
+    start_date DATE, end_date DATE, focus_area TEXT, deadline TEXT, beneficiaries INTEGER,
+    location TEXT, objective TEXT, progress INTEGER, ods_id INTEGER
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_relationship (
+    company_key TEXT REFERENCES scenario_company(logical_key),
+    project_key TEXT REFERENCES scenario_project(logical_key), status TEXT, initiator TEXT,
+    company_confirmed_at TIMESTAMP, npo_confirmed_at TIMESTAMP, responded_at TIMESTAMP,
+    expires_at TIMESTAMP, PRIMARY KEY (company_key, project_key)
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_report (
+    logical_key TEXT PRIMARY KEY, npo_key TEXT REFERENCES scenario_npo(logical_key),
+    reporter_company_key TEXT REFERENCES scenario_company(logical_key), reason TEXT, status TEXT
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_id_map (
+    entity_type TEXT, logical_key TEXT, id BIGINT, PRIMARY KEY (entity_type, logical_key)
+) ON COMMIT DROP;
+CREATE TEMP TABLE scenario_database_guard ON COMMIT DROP AS
+SELECT concat_ws(', ',
+    CASE WHEN EXISTS (SELECT 1 FROM address) THEN 'address' END,
+    CASE WHEN EXISTS (SELECT 1 FROM company) THEN 'company' END,
+    CASE WHEN EXISTS (SELECT 1 FROM npo) THEN 'npo' END, CASE WHEN EXISTS (SELECT 1 FROM project) THEN 'project' END,
+    CASE WHEN EXISTS (SELECT 1 FROM project_ods) THEN 'project_ods' END,
+    CASE WHEN EXISTS (SELECT 1 FROM company_project) THEN 'company_project' END,
+    CASE WHEN EXISTS (SELECT 1 FROM npo_report) THEN 'npo_report' END,
+    CASE WHEN EXISTS (SELECT 1 FROM document) THEN 'document' END, CASE WHEN EXISTS (SELECT 1 FROM edital) THEN 'edital' END
+) AS populated;
+
+INSERT INTO scenario_user VALUES
+('company_empty', 'e2e.company.empty@vinculohub.test', 'company'),
+('company_active', 'e2e.company.active@vinculohub.test', 'company'),
+('company_multiple', 'e2e.company.multiple@vinculohub.test', 'company'),
+('npo_projects', 'e2e.npo.projects@vinculohub.test', 'npo'),
+('npo_reported', 'e2e.npo.reported@vinculohub.test', 'npo');
+INSERT INTO scenario_address VALUES
+('company_empty', 'Sao Paulo', 'SP', 'Sao Paulo', 'Rua das Flores', '10', '01001-000'),
+('company_active', 'Rio Grande do Sul', 'RS', 'Porto Alegre', 'Rua da Industria', '20', '90010-000'),
+('company_multiple', 'Parana', 'PR', 'Curitiba', 'Avenida Central', '30', '80010-000'),
+('npo_projects', 'Rio de Janeiro', 'RJ', 'Rio de Janeiro', 'Rua da Educacao', '40', '20010-000'),
+('npo_reported', 'Bahia', 'BA', 'Salvador', 'Rua da Cidadania', '50', '40010-000');
+INSERT INTO scenario_company VALUES
+('company_empty', 'company_empty', 'company_empty', 'Empresa Horizonte Ltda', 'Horizonte', 'Empresa sem vinculos.', '11.222.333/0001-81', '1130001000'),
+('company_active', 'company_active', 'company_active', 'Empresa Alianca Ltda', 'Alianca', 'Empresa com vinculo ativo.', '12.345.678/0001-95', '5130002000'),
+('company_multiple', 'company_multiple', 'company_multiple', 'Empresa Multipla Ltda', 'Multipla', 'Empresa com varios vinculos.', '04.252.011/0001-10', '4130003000');
+INSERT INTO scenario_npo VALUES
+('npo_projects', 'npo_projects', 'npo_projects', 'Instituto Projetos Vivos', 'ONG com projetos ativos.', 'medium', '529.982.247-25', '2130004000', true, true, false),
+('npo_reported', 'npo_reported', 'npo_reported', 'Instituto Cidadania', 'ONG com denuncias registradas.', 'small', '168.995.350-09', '7130005000', false, true, true);
+INSERT INTO scenario_project VALUES
+('education', 'npo_projects', 'Educacao para Todos', 'Ampliacao do acesso a educacao de qualidade.', 'ACTIVE', 'SOCIAL', 120000, 45000, '2026-01-10', '2026-12-10', 'Educacao', '2026-09-30', 500, 'Rio de Janeiro', 'Atender estudantes da rede publica.', 40, 4),
+('climate', 'npo_projects', 'Clima em Acao', 'Formacao comunitaria para resiliencia climatica.', 'ACTIVE', 'ENVIRONMENTAL', 90000, 20000, '2026-02-01', '2026-11-30', 'Clima', '2026-08-31', 300, 'Niteroi', 'Preparar comunidades para eventos climaticos.', 25, 13),
+('cities', 'npo_projects', 'Bairros Sustentaveis', 'Melhorias urbanas conduzidas pela comunidade.', 'ACTIVE', 'GOVERNMENTAL', 150000, 60000, '2026-03-01', '2027-02-28', 'Cidades', '2026-10-31', 800, 'Duque de Caxias', 'Fortalecer infraestrutura comunitaria.', 55, 11),
+('poverty', 'npo_reported', 'Renda e Autonomia', 'Capacitacao profissional para familias vulneraveis.', 'ACTIVE', 'SOCIAL', 70000, 15000, '2026-01-15', '2026-10-15', 'Renda', '2026-07-31', 200, 'Salvador', 'Promover autonomia financeira.', 30, 1);
+INSERT INTO scenario_relationship VALUES
+('company_active', 'education', 'active', 'company', '2026-02-03 10:00', '2026-02-04 10:00', '2026-02-02 10:00', '2026-03-02 10:00'),
+('company_multiple', 'climate', 'negotiation', 'company', '2026-03-03 10:00', NULL, '2026-03-02 10:00', '2026-04-02 10:00'),
+('company_multiple', 'cities', 'pending', 'npo', NULL, NULL, NULL, NULL),
+('company_multiple', 'poverty', 'active', 'npo', '2026-04-03 10:00', '2026-04-04 10:00', '2026-04-02 10:00', '2026-05-02 10:00');
+INSERT INTO scenario_report VALUES
+('report_open', 'npo_reported', 'company_active', 'Informacoes de prestacao de contas precisam de verificacao.', 'OPEN'),
+('report_resolved', 'npo_reported', 'company_multiple', 'Documento institucional estava temporariamente indisponivel.', 'RESOLVED');

--- a/backend/src/main/resources/db/test-scenarios/02_scenario_persistence.sql
+++ b/backend/src/main/resources/db/test-scenarios/02_scenario_persistence.sql
@@ -1,0 +1,64 @@
+INSERT INTO scenario_id_map
+SELECT 'address', logical_key, nextval(pg_get_serial_sequence('address', 'id')) FROM scenario_address
+UNION ALL SELECT 'company', logical_key, nextval(pg_get_serial_sequence('company', 'id')) FROM scenario_company
+UNION ALL SELECT 'npo', logical_key, nextval(pg_get_serial_sequence('npo', 'id')) FROM scenario_npo
+UNION ALL SELECT 'project', logical_key, nextval(pg_get_serial_sequence('project', 'id')) FROM scenario_project;
+
+INSERT INTO address (id, state, state_code, city, street, number, zip_code, created_at, updated_at)
+SELECT ids.id, s.state, s.state_code, s.city, s.street, s.number, s.zip_code,
+       '2026-01-01 09:00', '2026-01-01 09:00'
+FROM scenario_address s JOIN scenario_id_map ids
+  ON ids.entity_type = 'address' AND ids.logical_key = s.logical_key;
+
+INSERT INTO company (id, user_id, address_id, legal_name, social_name, description, cnpj, phone, created_at, updated_at)
+SELECT ids.id, u.id, address_ids.id, s.legal_name, s.social_name, s.description, s.cnpj,
+       s.phone, '2026-01-01 09:00', '2026-01-01 09:00'
+FROM scenario_company s
+JOIN scenario_id_map ids ON ids.entity_type = 'company' AND ids.logical_key = s.logical_key
+JOIN scenario_id_map address_ids ON address_ids.entity_type = 'address' AND address_ids.logical_key = s.address_key
+JOIN scenario_user su ON su.logical_key = s.user_key
+JOIN users u ON lower(u.email) = lower(su.email);
+
+INSERT INTO npo (id, user_id, address_id, name, description, npo_size, cpf, phone,
+                 environmental, social, governance, created_at, updated_at)
+SELECT ids.id, u.id, address_ids.id, s.name, s.description, s.npo_size::npo_size, s.cpf,
+       s.phone, s.environmental, s.social, s.governance, '2026-01-01 09:00', '2026-01-01 09:00'
+FROM scenario_npo s
+JOIN scenario_id_map ids ON ids.entity_type = 'npo' AND ids.logical_key = s.logical_key
+JOIN scenario_id_map address_ids ON address_ids.entity_type = 'address' AND address_ids.logical_key = s.address_key
+JOIN scenario_user su ON su.logical_key = s.user_key
+JOIN users u ON lower(u.email) = lower(su.email);
+
+INSERT INTO project (id, npo_id, title, description, status, project_type, budget_needed,
+                     invested_amount, start_date, end_date, focus_area, fundraising_deadline,
+                     beneficiaries_count, location, main_objective, progress, created_at, updated_at)
+SELECT ids.id, npo_ids.id, s.title, s.description, s.status, s.project_type, s.budget, s.invested,
+       s.start_date, s.end_date, s.focus_area, s.deadline, s.beneficiaries, s.location,
+       s.objective, s.progress, '2026-01-01 09:00', '2026-01-01 09:00'
+FROM scenario_project s
+JOIN scenario_id_map ids ON ids.entity_type = 'project' AND ids.logical_key = s.logical_key
+JOIN scenario_id_map npo_ids ON npo_ids.entity_type = 'npo' AND npo_ids.logical_key = s.npo_key;
+
+INSERT INTO project_ods (project_id, ods_id)
+SELECT ids.id, s.ods_id FROM scenario_project s JOIN scenario_id_map ids
+  ON ids.entity_type = 'project' AND ids.logical_key = s.logical_key;
+
+INSERT INTO company_project (company_id, project_id, status, initiator_type, company_confirmed_at,
+                             npo_confirmed_at, responded_at, expires_at, created_at, updated_at)
+SELECT company_ids.id, project_ids.id, s.status::relationship_status, s.initiator::initiator_type,
+       s.company_confirmed_at, s.npo_confirmed_at, s.responded_at, s.expires_at,
+       '2026-01-01 09:00', '2026-01-01 09:00'
+FROM scenario_relationship s
+JOIN scenario_id_map company_ids
+  ON company_ids.entity_type = 'company' AND company_ids.logical_key = s.company_key
+JOIN scenario_id_map project_ids
+  ON project_ids.entity_type = 'project' AND project_ids.logical_key = s.project_key;
+
+INSERT INTO npo_report (npo_id, reporter_company_id, reporter_user_id, reason, status, created_at, updated_at)
+SELECT npo_ids.id, company_ids.id, c.user_id, s.reason, s.status,
+       '2026-05-01 09:00', '2026-05-01 09:00'
+FROM scenario_report s
+JOIN scenario_id_map npo_ids ON npo_ids.entity_type = 'npo' AND npo_ids.logical_key = s.npo_key
+JOIN scenario_id_map company_ids
+  ON company_ids.entity_type = 'company' AND company_ids.logical_key = s.reporter_company_key
+JOIN company c ON c.id = company_ids.id;

--- a/backend/src/test/java/com/vinculohub/backend/config/TestScenarioSeederIntegrationTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/config/TestScenarioSeederIntegrationTest.java
@@ -1,0 +1,95 @@
+/* (C)2026 */
+package com.vinculohub.backend.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.vinculohub.backend.database.AbstractIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.PlatformTransactionManager;
+
+class TestScenarioSeederIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    @Autowired(required = false)
+    private TestScenarioSeeder configuredSeeder;
+
+    @AfterEach
+    void cleanUp() {
+        reset();
+    }
+
+    @Test
+    void coversCatalogGuardsAndRollback() {
+        TestScenarioSeeder seeder = new TestScenarioSeeder(jdbc, transactionManager);
+        reset();
+        assertThat(configuredSeeder).isNull();
+        assertThat(tableCounts("company", "npo", "project")).containsOnly(0);
+
+        insertUsers();
+        seeder.run();
+        assertThat(tableCounts("company", "npo", "project", "company_project", "npo_report"))
+                .containsExactly(3, 2, 4, 4, 2);
+        assertThat(
+                        jdbc.queryForObject(
+                                "SELECT (SELECT array_agg(ods_id ORDER BY ods_id) FROM project_ods)"
+                                    + " = ARRAY[1,4,11,13] AND (SELECT array_agg(status::text ORDER"
+                                    + " BY status::text) FROM company_project) ="
+                                    + " ARRAY['active','active','negotiation','pending'] AND"
+                                    + " (SELECT bool_and(r.reporter_user_id = c.user_id) FROM"
+                                    + " npo_report r JOIN company c ON c.id ="
+                                    + " r.reporter_company_id)",
+                                Boolean.class))
+                .isTrue();
+
+        reset();
+        insertUsers();
+        jdbc.update("DELETE FROM users WHERE email = 'e2e.npo.reported@vinculohub.test'");
+        assertThatThrownBy(() -> seeder.run())
+                .hasMessageContaining("e2e.npo.reported@vinculohub.test");
+        reset();
+        insertUsers();
+        jdbc.update(
+                "UPDATE users SET user_type = 'admin' "
+                        + "WHERE email = 'e2e.npo.projects@vinculohub.test'");
+        assertThatThrownBy(() -> seeder.run()).hasMessageContaining("expected npo, found admin");
+        reset();
+        insertUsers();
+        jdbc.update("INSERT INTO address (city) VALUES ('Existing')");
+        assertThatThrownBy(() -> seeder.run()).hasMessageContaining("address");
+
+        reset();
+        insertUsers();
+        jdbc.execute(
+                "CREATE FUNCTION fail_test_scenario_project() RETURNS trigger LANGUAGE plpgsql "
+                        + "AS $$ BEGIN RAISE EXCEPTION 'forced project failure'; END $$");
+        jdbc.execute(
+                "CREATE TRIGGER fail_test_scenario_project BEFORE INSERT ON project "
+                        + "FOR EACH ROW EXECUTE FUNCTION fail_test_scenario_project()");
+        assertThatThrownBy(() -> seeder.run())
+                .rootCause()
+                .hasMessageContaining("forced project failure");
+        assertThat(tableCounts("company", "npo", "project")).containsOnly(0);
+    }
+
+    private void reset() {
+        jdbc.execute("DROP TRIGGER IF EXISTS fail_test_scenario_project ON project");
+        jdbc.execute("DROP FUNCTION IF EXISTS fail_test_scenario_project()");
+        truncateFunctionalTables();
+    }
+
+    private void insertUsers() {
+        jdbc.execute(
+                """
+INSERT INTO users (name, email, auth0_id, user_type) VALUES
+('Empty Company', 'e2e.company.empty@vinculohub.test', 'auth0|empty', 'company'),
+('Active Company', 'e2e.company.active@vinculohub.test', 'auth0|active', 'company'),
+('Multiple Company', 'e2e.company.multiple@vinculohub.test', 'auth0|multiple', 'company'),
+('Projects NPO', 'e2e.npo.projects@vinculohub.test', 'auth0|projects', 'npo'),
+('Reported NPO', 'e2e.npo.reported@vinculohub.test', 'auth0|reported', 'npo')
+""");
+    }
+}

--- a/backend/src/test/java/com/vinculohub/backend/database/AbstractIntegrationTest.java
+++ b/backend/src/test/java/com/vinculohub/backend/database/AbstractIntegrationTest.java
@@ -1,8 +1,12 @@
 /* (C)2026 */
 package com.vinculohub.backend.database;
 
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -12,6 +16,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 public abstract class AbstractIntegrationTest {
+
+    @Autowired protected JdbcTemplate jdbc;
 
     private static final PostgreSQLContainer<?> POSTGRES =
             new PostgreSQLContainer<>("postgres:16-alpine")
@@ -33,5 +39,17 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.flyway.url", POSTGRES::getJdbcUrl);
         registry.add("spring.flyway.user", POSTGRES::getUsername);
         registry.add("spring.flyway.password", POSTGRES::getPassword);
+    }
+
+    protected void truncateFunctionalTables() {
+        jdbc.execute(
+                "TRUNCATE npo_report, company_project, project_ods, document, edital, project, "
+                        + "npo, company, address, users RESTART IDENTITY CASCADE");
+    }
+
+    protected List<Integer> tableCounts(String... tables) {
+        return Arrays.stream(tables)
+                .map(table -> jdbc.queryForObject("SELECT count(*) FROM " + table, Integer.class))
+                .toList();
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - AUTH0_ISSUER_URI=${AUTH0_ISSUER_URI}
       - AUTH0_AUDIENCE=${AUTH0_AUDIENCE}
       - AUTH0_ROLES_CLAIM=${AUTH0_ROLES_CLAIM:-https://vinculohub/roles}
+      - APP_TEST_SCENARIOS_ENABLED=${APP_TEST_SCENARIOS_ENABLED:-false}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Issue Link
Closes #--nocloses

## Description
Esta branch implementa uma feature de cenários de dados para ambientes de desenvolvimento e testes E2E. A ideia é permitir que a aplicação, quando configurada, popule automaticamente um banco funcionalmente vazio com um catálogo fixo de entidades representativas do domínio.

## Task Notes
* Este PR é uma implementação mais nova da feature que estava sendo trabalhada no PR #300
 * A feature/task ainda pode sofrer alterações radicais que a implementação atual, pois atualmente ela não é um requisito funcional que esta no backlog
 
## Screenshots